### PR TITLE
feat: add passbolt_group members support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v1.5.0 — 2026-04-15
+
+### ✨ Added
+
+- `passbolt_group.members` now manages regular group members alongside required group managers.
+
+### 🛠 Improved
+
+- `passbolt_group` now validates that users are not configured as both managers and members.
+
 ## v1.4.0 — 2026-04-10
 
 ### ✨ Added

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BINARY_NAME=terraform-provider-passbolt
-VERSION=1.0.5
+VERSION=1.5.0
 OS=$(shell uname | tr A-Z a-z)
 ARCH=amd64
 PLUGIN_NAMESPACE=bald1nh0

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Self-hosted open-source team password manager, with folder, sharing and SSM/auto
 - Grant and revoke group permission to folders (`passbolt_folder_permission` resource)
 - Integration-ready with AWS SSM, Secrets Manager, and other tools
 - Use with your own Passbolt instance (CE or PRO)
-- Manage user groups via `passbolt_group` (with manager assignment)
+- Manage user groups via `passbolt_group` (with manager and member assignment)
 - Look up users by email using `data "passbolt_user"`
 
 ---
@@ -186,10 +186,16 @@ data "passbolt_user" "dev_manager" {
   username = "dev.lead@example.com"
 }
 
+data "passbolt_user" "dev_member" {
+  username = "dev.member@example.com"
+}
+
 resource "passbolt_group" "developers" {
   name     = "Developers"
   managers = [data.passbolt_user.dev_manager.id]
+  members  = [data.passbolt_user.dev_member.id]
 }
+```
 
 ---
 
@@ -199,10 +205,13 @@ resource "passbolt_group" "developers" {
 resource "passbolt_group" "example" {
   name     = "Terraform Group Example"
   managers = ["2a61bc5d-bbbb-aaaa-cccc-123456789abc"] # Must be active Passbolt user UUID
+  members  = ["3b72cd6e-cccc-bbbb-dddd-23456789abcd"] # Optional regular group members
 }
 ```
 
-You can look up user UUIDs using data "passbolt_user" or manually fetch from Passbolt
+Passbolt requires at least one group manager. Regular members can be managed with `members`, and a user must not be present in both `managers` and `members`.
+
+You can look up user UUIDs using `data "passbolt_user"` or manually fetch them from Passbolt.
 
 ---
 
@@ -266,6 +275,7 @@ output "all_folder_paths" {
   - `PASSBOLT_PASSPHRASE`
   - `PASSBOLT_MANAGER_ID`
   - `PASSBOLT_TEST_USER_EMAIL`
+  - `PASSBOLT_MEMBER_ID` (optional; must be different from `PASSBOLT_MANAGER_ID`)
 
 ---
 

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -26,9 +26,15 @@ variable "manager_id" {
   type        = string
 }
 
+variable "member_id" {
+  description = "The UUID of an existing active Passbolt user to add as a regular group member"
+  type        = string
+}
+
 resource "passbolt_group" "example" {
   name     = "Terraform Group Example"
   managers = [var.manager_id]
+  members  = [var.member_id]
 }
 ```
 
@@ -39,6 +45,10 @@ resource "passbolt_group" "example" {
 
 - `managers` (List of String) List of user IDs to assign as group managers.
 - `name` (String) Group name.
+
+### Optional
+
+- `members` (List of String) List of user IDs to assign as regular group members.
 
 ### Read-Only
 

--- a/examples/resources/passbolt_group/resource.tf
+++ b/examples/resources/passbolt_group/resource.tf
@@ -11,7 +11,13 @@ variable "manager_id" {
   type        = string
 }
 
+variable "member_id" {
+  description = "The UUID of an existing active Passbolt user to add as a regular group member"
+  type        = string
+}
+
 resource "passbolt_group" "example" {
   name     = "Terraform Group Example"
   managers = [var.manager_id]
+  members  = [var.member_id]
 }

--- a/internal/provider/acceptance_helpers_test.go
+++ b/internal/provider/acceptance_helpers_test.go
@@ -39,5 +39,5 @@ func testAccName(prefix, suffix string) string {
 }
 
 func testAccEmail(prefix, suffix string) string {
-	return fmt.Sprintf("%s-%s@example.com", prefix, suffix)
+	return fmt.Sprintf("test-%s-%s@bald1nh0.net", prefix, suffix)
 }

--- a/internal/provider/group_resource.go
+++ b/internal/provider/group_resource.go
@@ -3,14 +3,18 @@ package provider
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"terraform-provider-passbolt/tools"
 
 	"github.com/passbolt/go-passbolt/helper"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -34,6 +38,7 @@ type groupModel struct {
 	ID       types.String   `tfsdk:"id"`
 	Name     types.String   `tfsdk:"name"`
 	Managers []types.String `tfsdk:"managers"`
+	Members  []types.String `tfsdk:"members"`
 }
 
 func (r *groupResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
@@ -82,6 +87,22 @@ func (r *groupResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				ElementType: types.StringType,
 				Required:    true,
 				Description: "List of user IDs to assign as group managers.",
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+					listvalidator.NoNullValues(),
+					listvalidator.UniqueValues(),
+					listvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1)),
+				},
+			},
+			"members": schema.ListAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+				Description: "List of user IDs to assign as regular group members.",
+				Validators: []validator.List{
+					listvalidator.NoNullValues(),
+					listvalidator.UniqueValues(),
+					listvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1)),
+				},
 			},
 		},
 	}
@@ -94,13 +115,13 @@ func (r *groupResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
-	ops := make([]helper.GroupMembershipOperation, 0, len(plan.Managers))
-	for _, uid := range plan.Managers {
-		ops = append(ops, helper.GroupMembershipOperation{
-			UserID:         uid.ValueString(),
-			IsGroupManager: true,
-		})
+	if err := validateGroupMembershipConfig(plan.Managers, plan.Members); err != nil {
+		resp.Diagnostics.AddError("Invalid group membership", err.Error())
+
+		return
 	}
+
+	ops := buildCreateGroupMembershipOps(plan.Managers, plan.Members)
 
 	groupID, err := helper.CreateGroup(ctx, r.client.Client, plan.Name.ValueString(), ops)
 	if err != nil {
@@ -128,13 +149,11 @@ func (r *groupResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	}
 
 	state.Name = types.StringValue(name)
-	var managerIDs []types.String
-	for _, m := range memberships {
-		if m.IsGroupManager {
-			managerIDs = append(managerIDs, types.StringValue(m.UserID))
-		}
-	}
+	managerIDs, memberIDs := splitGroupMemberships(memberships, state.Members != nil)
 	state.Managers = managerIDs
+	if state.Members != nil {
+		state.Members = memberIDs
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -149,9 +168,25 @@ func (r *groupResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
-	added, removed := detectManagerChanges(plan.Managers, state.Managers)
+	if err := validateGroupMembershipConfig(plan.Managers, plan.Members); err != nil {
+		resp.Diagnostics.AddError("Invalid group membership", err.Error())
 
-	ops := buildGroupMembershipOps(added, removed)
+		return
+	}
+
+	stateManagers := state.Managers
+	stateMembers := state.Members
+	if shouldManageRegularMembers(plan.Members, state.Members) {
+		_, memberships, err := helper.GetGroup(ctx, r.client.Client, state.ID.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("Error reading group memberships", err.Error())
+
+			return
+		}
+		stateManagers, stateMembers = splitGroupMemberships(memberships, true)
+	}
+
+	ops := buildGroupMembershipOps(plan.Managers, plan.Members, stateManagers, stateMembers)
 
 	err := helper.UpdateGroup(ctx, r.client.Client, state.ID.ValueString(), plan.Name.ValueString(), ops)
 	if err != nil {
@@ -164,41 +199,154 @@ func (r *groupResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
-func detectManagerChanges(planManagers, stateManagers []types.String) (added, removed map[string]bool) {
-	newSet := make(map[string]bool)
-	removed = make(map[string]bool)
-	added = make(map[string]bool)
+func splitGroupMemberships(
+	memberships []helper.GroupMembership,
+	includeMembers bool,
+) ([]types.String, []types.String) {
+	managerIDs := make([]types.String, 0, len(memberships))
+	memberIDs := make([]types.String, 0, len(memberships))
 
-	for _, uid := range planManagers {
-		newSet[uid.ValueString()] = true
-	}
-
-	for _, old := range stateManagers {
-		oldID := old.ValueString()
-		if !newSet[oldID] {
-			removed[oldID] = true
+	for _, membership := range memberships {
+		if membership.IsGroupManager {
+			managerIDs = append(managerIDs, types.StringValue(membership.UserID))
+		} else if includeMembers {
+			memberIDs = append(memberIDs, types.StringValue(membership.UserID))
 		}
 	}
 
-	for uid := range newSet {
-		if !contains(stateManagers, uid) {
-			added[uid] = true
-		}
-	}
-
-	return
+	return managerIDs, memberIDs
 }
 
-func buildGroupMembershipOps(added, removed map[string]bool) []helper.GroupMembershipOperation {
-	ops := make([]helper.GroupMembershipOperation, 0, len(added)+len(removed))
+func shouldManageRegularMembers(planMembers, stateMembers []types.String) bool {
+	return planMembers != nil || stateMembers != nil
+}
 
-	for uid := range added {
+func validateGroupMembershipConfig(managers, members []types.String) error {
+	if len(managers) == 0 {
+		return fmt.Errorf("at least one group manager is required")
+	}
+
+	overlap := overlappingGroupUsers(managers, members)
+	if len(overlap) > 0 {
+		return fmt.Errorf("users cannot be both managers and members: %v", overlap)
+	}
+
+	return nil
+}
+
+func overlappingGroupUsers(managers, members []types.String) []string {
+	managerSet := groupUserSet(managers)
+	overlap := make([]string, 0, len(members))
+
+	for _, uid := range members {
+		userID := uid.ValueString()
+		if managerSet[userID] {
+			overlap = append(overlap, userID)
+		}
+	}
+
+	slices.Sort(overlap)
+
+	return overlap
+}
+
+func buildCreateGroupMembershipOps(managers, members []types.String) []helper.GroupMembershipOperation {
+	ops := make([]helper.GroupMembershipOperation, 0, len(managers)+len(members))
+
+	for _, uid := range managers {
 		ops = append(ops, helper.GroupMembershipOperation{
-			UserID:         uid,
+			UserID:         uid.ValueString(),
 			IsGroupManager: true,
 		})
 	}
-	for uid := range removed {
+
+	for _, uid := range members {
+		ops = append(ops, helper.GroupMembershipOperation{
+			UserID:         uid.ValueString(),
+			IsGroupManager: false,
+		})
+	}
+
+	return ops
+}
+
+func buildGroupMembershipOps(
+	planManagers,
+	planMembers,
+	stateManagers,
+	stateMembers []types.String,
+) []helper.GroupMembershipOperation {
+	desired := groupUserRoleMap(planManagers, planMembers)
+	current := groupUserRoleMap(stateManagers, stateMembers)
+	userIDs := groupUserIDs(desired, current)
+
+	ops := make([]helper.GroupMembershipOperation, 0, len(userIDs))
+	ops = appendMembershipRoleChanges(ops, userIDs, desired, current, true)
+	ops = appendNewGroupMembers(ops, userIDs, desired, current)
+	ops = appendMembershipRoleChanges(ops, userIDs, desired, current, false)
+	ops = appendRemovedGroupUsers(ops, userIDs, desired, current)
+
+	return ops
+}
+
+func appendMembershipRoleChanges(
+	ops []helper.GroupMembershipOperation,
+	userIDs []string,
+	desired,
+	current map[string]bool,
+	isGroupManager bool,
+) []helper.GroupMembershipOperation {
+	for _, uid := range userIDs {
+		desiredRole, desiredExists := desired[uid]
+		currentRole := current[uid]
+		if !desiredExists || desiredRole != isGroupManager || currentRole == desiredRole {
+			continue
+		}
+		ops = append(ops, helper.GroupMembershipOperation{
+			UserID:         uid,
+			IsGroupManager: desiredRole,
+		})
+	}
+
+	return ops
+}
+
+func appendNewGroupMembers(
+	ops []helper.GroupMembershipOperation,
+	userIDs []string,
+	desired,
+	current map[string]bool,
+) []helper.GroupMembershipOperation {
+	for _, uid := range userIDs {
+		desiredRole, desiredExists := desired[uid]
+		if !desiredExists || desiredRole {
+			continue
+		}
+		if _, currentExists := current[uid]; currentExists {
+			continue
+		}
+		ops = append(ops, helper.GroupMembershipOperation{
+			UserID:         uid,
+			IsGroupManager: false,
+		})
+	}
+
+	return ops
+}
+
+func appendRemovedGroupUsers(
+	ops []helper.GroupMembershipOperation,
+	userIDs []string,
+	desired,
+	current map[string]bool,
+) []helper.GroupMembershipOperation {
+	for _, uid := range userIDs {
+		if _, currentExists := current[uid]; !currentExists {
+			continue
+		}
+		if _, desiredExists := desired[uid]; desiredExists {
+			continue
+		}
 		ops = append(ops, helper.GroupMembershipOperation{
 			UserID: uid,
 			Delete: true,
@@ -208,14 +356,44 @@ func buildGroupMembershipOps(added, removed map[string]bool) []helper.GroupMembe
 	return ops
 }
 
-func contains(users []types.String, uid string) bool {
-	for _, u := range users {
-		if u.ValueString() == uid {
-			return true
+func groupUserRoleMap(managers, members []types.String) map[string]bool {
+	roles := make(map[string]bool, len(managers)+len(members))
+
+	for _, uid := range members {
+		roles[uid.ValueString()] = false
+	}
+
+	for _, uid := range managers {
+		roles[uid.ValueString()] = true
+	}
+
+	return roles
+}
+
+func groupUserSet(users []types.String) map[string]bool {
+	result := make(map[string]bool, len(users))
+	for _, uid := range users {
+		result[uid.ValueString()] = true
+	}
+
+	return result
+}
+
+func groupUserIDs(roleMaps ...map[string]bool) []string {
+	seen := make(map[string]bool)
+	for _, roleMap := range roleMaps {
+		for uid := range roleMap {
+			seen[uid] = true
 		}
 	}
 
-	return false
+	userIDs := make([]string, 0, len(seen))
+	for uid := range seen {
+		userIDs = append(userIDs, uid)
+	}
+	slices.Sort(userIDs)
+
+	return userIDs
 }
 
 func (r *groupResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/group_resource_internal_test.go
+++ b/internal/provider/group_resource_internal_test.go
@@ -1,0 +1,148 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/passbolt/go-passbolt/helper"
+)
+
+func TestValidateGroupMembershipConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		managers []types.String
+		members  []types.String
+		wantErr  bool
+	}{
+		"valid": {
+			managers: stringValues("manager-1"),
+			members:  stringValues("member-1"),
+		},
+		"requires manager": {
+			members: stringValues("member-1"),
+			wantErr: true,
+		},
+		"rejects overlap": {
+			managers: stringValues("user-1"),
+			members:  stringValues("user-1"),
+			wantErr:  true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateGroupMembershipConfig(test.managers, test.members)
+			if test.wantErr && err == nil {
+				t.Fatalf("expected validation error")
+			}
+			if !test.wantErr && err != nil {
+				t.Fatalf("unexpected validation error: %v", err)
+			}
+		})
+	}
+}
+
+func TestBuildCreateGroupMembershipOps(t *testing.T) {
+	t.Parallel()
+
+	got := buildCreateGroupMembershipOps(
+		stringValues("manager-1"),
+		stringValues("member-1", "member-2"),
+	)
+
+	want := []helper.GroupMembershipOperation{
+		{UserID: "manager-1", IsGroupManager: true},
+		{UserID: "member-1", IsGroupManager: false},
+		{UserID: "member-2", IsGroupManager: false},
+	}
+
+	assertGroupMembershipOps(t, got, want)
+}
+
+func TestBuildGroupMembershipOps(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		planManagers  []types.String
+		planMembers   []types.String
+		stateManagers []types.String
+		stateMembers  []types.String
+		want          []helper.GroupMembershipOperation
+	}{
+		"adds updates and removes memberships": {
+			planManagers:  stringValues("manager-b", "member-a"),
+			planMembers:   stringValues("member-b"),
+			stateManagers: stringValues("manager-a"),
+			stateMembers:  stringValues("member-a", "member-old"),
+			want: []helper.GroupMembershipOperation{
+				{UserID: "manager-b", IsGroupManager: true},
+				{UserID: "member-a", IsGroupManager: true},
+				{UserID: "member-b", IsGroupManager: false},
+				{UserID: "manager-a", Delete: true},
+				{UserID: "member-old", Delete: true},
+			},
+		},
+		"promotes before demoting": {
+			planManagers:  stringValues("manager-b"),
+			planMembers:   stringValues("manager-a"),
+			stateManagers: stringValues("manager-a"),
+			stateMembers:  stringValues("manager-b"),
+			want: []helper.GroupMembershipOperation{
+				{UserID: "manager-b", IsGroupManager: true},
+				{UserID: "manager-a", IsGroupManager: false},
+			},
+		},
+		"no changes": {
+			planManagers:  stringValues("manager-a"),
+			planMembers:   stringValues("member-a"),
+			stateManagers: stringValues("manager-a"),
+			stateMembers:  stringValues("member-a"),
+			want:          []helper.GroupMembershipOperation{},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := buildGroupMembershipOps(
+				test.planManagers,
+				test.planMembers,
+				test.stateManagers,
+				test.stateMembers,
+			)
+
+			assertGroupMembershipOps(t, got, test.want)
+		})
+	}
+}
+
+func stringValues(values ...string) []types.String {
+	result := make([]types.String, 0, len(values))
+	for _, value := range values {
+		result = append(result, types.StringValue(value))
+	}
+
+	return result
+}
+
+func assertGroupMembershipOps(
+	t *testing.T,
+	got,
+	want []helper.GroupMembershipOperation,
+) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("expected %d ops, got %d: %#v", len(want), len(got), got)
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("op %d: expected %#v, got %#v", i, want[i], got[i])
+		}
+	}
+}

--- a/internal/provider/group_resource_test.go
+++ b/internal/provider/group_resource_test.go
@@ -1,11 +1,13 @@
 package provider_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/passbolt/go-passbolt/api"
 )
 
 func TestAccPassboltGroup_fullLifecycle(t *testing.T) {
@@ -31,11 +33,89 @@ func TestAccPassboltGroup_fullLifecycle(t *testing.T) {
 	})
 }
 
+func TestAccPassboltGroup_withMembers(t *testing.T) {
+	t.Parallel()
+
+	requireAcceptanceEnv(
+		t,
+		"PASSBOLT_BASE_URL",
+		"PASSBOLT_PRIVATE_KEY",
+		"PASSBOLT_PASSPHRASE",
+		"PASSBOLT_MANAGER_ID",
+	)
+
+	baseURL := os.Getenv("PASSBOLT_BASE_URL")
+	privateKey := os.Getenv("PASSBOLT_PRIVATE_KEY")
+	passphrase := os.Getenv("PASSBOLT_PASSPHRASE")
+	managerID := os.Getenv("PASSBOLT_MANAGER_ID")
+	memberID := testAccGroupMemberID(t, baseURL, privateKey, passphrase, managerID)
+	suffix := testAccSuffix()
+	groupName := testAccName("test-group-members", suffix)
+	updatedGroupName := testAccName("renamed-group-members", suffix)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			testStepCreateGroupWithMembers(baseURL, privateKey, passphrase, managerID, memberID, groupName),
+			testStepNoDriftGroupWithMembers(baseURL, privateKey, passphrase, managerID, memberID, groupName),
+			testStepUpdateGroupWithMembers(baseURL, privateKey, passphrase, managerID, memberID, updatedGroupName),
+		},
+	})
+}
+
+func testAccGroupMemberID(t *testing.T, baseURL, privateKey, passphrase, managerID string) string {
+	t.Helper()
+
+	memberID := os.Getenv("PASSBOLT_MEMBER_ID")
+	if memberID != "" {
+		if memberID == managerID {
+			t.Skip("PASSBOLT_MEMBER_ID must be different from PASSBOLT_MANAGER_ID")
+		}
+
+		return memberID
+	}
+
+	memberEmail := os.Getenv("PASSBOLT_TEST_USER_EMAIL")
+	if memberEmail == "" {
+		t.Skip("PASSBOLT_MEMBER_ID or PASSBOLT_TEST_USER_EMAIL is required for group member acceptance tests")
+	}
+
+	ctx := context.Background()
+	client, err := api.NewClient(nil, "", baseURL, privateKey, passphrase)
+	if err != nil {
+		t.Fatalf("failed to create Passbolt API client: %v", err)
+	}
+	if err := client.Login(ctx); err != nil {
+		t.Fatalf("failed to log in to Passbolt API: %v", err)
+	}
+	defer func() {
+		_ = client.Logout(ctx)
+	}()
+
+	users, err := client.GetUsers(ctx, &api.GetUsersOptions{
+		FilterSearch: memberEmail,
+	})
+	if err != nil {
+		t.Fatalf("failed to look up member test user %q: %v", memberEmail, err)
+	}
+	if len(users) == 0 {
+		t.Skipf("PASSBOLT_TEST_USER_EMAIL %q did not match any user", memberEmail)
+	}
+
+	memberID = users[0].ID
+	if memberID == managerID {
+		t.Skip("PASSBOLT_TEST_USER_EMAIL resolves to PASSBOLT_MANAGER_ID; skipping group member acceptance test")
+	}
+
+	return memberID
+}
+
 func testStepCreateGroup(baseURL, privateKey, passphrase, managerID, groupName string) resource.TestStep {
 	return resource.TestStep{
 		Config: testGroupConfig(baseURL, privateKey, passphrase, managerID, groupName),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr("passbolt_group.test", "name", groupName),
+			resource.TestCheckResourceAttr("passbolt_group.test", "managers.#", "1"),
 		),
 	}
 }
@@ -45,6 +125,7 @@ func testStepNoDriftGroup(baseURL, privateKey, passphrase, managerID, groupName 
 		Config: testGroupConfig(baseURL, privateKey, passphrase, managerID, groupName),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr("passbolt_group.test", "name", groupName),
+			resource.TestCheckResourceAttr("passbolt_group.test", "managers.#", "1"),
 		),
 	}
 }
@@ -54,6 +135,61 @@ func testStepUpdateGroup(baseURL, privateKey, passphrase, managerID, groupName s
 		Config: testGroupConfig(baseURL, privateKey, passphrase, managerID, groupName),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr("passbolt_group.test", "name", groupName),
+			resource.TestCheckResourceAttr("passbolt_group.test", "managers.#", "1"),
+		),
+	}
+}
+
+func testStepCreateGroupWithMembers(
+	baseURL,
+	privateKey,
+	passphrase,
+	managerID,
+	memberID,
+	groupName string,
+) resource.TestStep {
+	return resource.TestStep{
+		Config: testGroupWithMembersConfig(baseURL, privateKey, passphrase, managerID, memberID, groupName),
+		Check: resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr("passbolt_group.test", "name", groupName),
+			resource.TestCheckResourceAttr("passbolt_group.test", "managers.#", "1"),
+			resource.TestCheckResourceAttr("passbolt_group.test", "members.#", "1"),
+		),
+	}
+}
+
+func testStepNoDriftGroupWithMembers(
+	baseURL,
+	privateKey,
+	passphrase,
+	managerID,
+	memberID,
+	groupName string,
+) resource.TestStep {
+	return resource.TestStep{
+		Config: testGroupWithMembersConfig(baseURL, privateKey, passphrase, managerID, memberID, groupName),
+		Check: resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr("passbolt_group.test", "name", groupName),
+			resource.TestCheckResourceAttr("passbolt_group.test", "managers.#", "1"),
+			resource.TestCheckResourceAttr("passbolt_group.test", "members.#", "1"),
+		),
+	}
+}
+
+func testStepUpdateGroupWithMembers(
+	baseURL,
+	privateKey,
+	passphrase,
+	managerID,
+	memberID,
+	groupName string,
+) resource.TestStep {
+	return resource.TestStep{
+		Config: testGroupWithMembersConfig(baseURL, privateKey, passphrase, managerID, memberID, groupName),
+		Check: resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr("passbolt_group.test", "name", groupName),
+			resource.TestCheckResourceAttr("passbolt_group.test", "managers.#", "1"),
+			resource.TestCheckResourceAttr("passbolt_group.test", "members.#", "1"),
 		),
 	}
 }
@@ -73,4 +209,22 @@ resource "passbolt_group" "test" {
   managers = ["%s"]
 }
 `, baseURL, privateKey, passphrase, groupName, managerID)
+}
+
+func testGroupWithMembersConfig(baseURL, privateKey, passphrase, managerID, memberID, groupName string) string {
+	return fmt.Sprintf(`
+provider "passbolt" {
+  base_url    = "%s"
+  private_key = <<EOF
+%s
+EOF
+  passphrase  = "%s"
+}
+
+resource "passbolt_group" "test" {
+  name     = "%s"
+  managers = ["%s"]
+  members  = ["%s"]
+}
+`, baseURL, privateKey, passphrase, groupName, managerID, memberID)
 }


### PR DESCRIPTION
## Changes

- Add optional `members` support to the `passbolt_group` resource.
- Keep `managers` required and validate that at least one group manager is configured.
- Validate that the same user is not present in both `managers` and `members`.
- Support membership role changes during updates:
  - add regular members
  - remove members
  - promote members to managers
  - demote managers to members
- Preserve backward compatibility for existing configs that only use `managers`.
- Add unit coverage for group membership operation planning.
- Add acceptance coverage for groups with regular members.
- Update generated provider docs, examples, README, and changelog.