### PR TITLE
Fix/active passbolt user lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.5.2 — 2026-04-17
+
+### 🛠 Fixed
+
+- `data.passbolt_user` now resolves only exact, active, non-deleted Passbolt users.
+- Improved `passbolt_user` data source behavior for deleted or stale Passbolt user records that could previously be returned by search results.
+
 ## v1.5.1 — 2026-04-17
 
 ### 🛠 Fixed

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BINARY_NAME=terraform-provider-passbolt
-VERSION=1.5.1
+VERSION=1.5.2
 OS=$(shell uname | tr A-Z a-z)
 ARCH=amd64
 PLUGIN_NAMESPACE=bald1nh0

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ OS=$(shell uname | tr A-Z a-z)
 ARCH=amd64
 PLUGIN_NAMESPACE=bald1nh0
 PLUGIN_PATH=~/.terraform.d/plugins/$(PLUGIN_NAMESPACE)/passbolt/$(VERSION)/$(OS)_$(ARCH)
-LOCAL_BIN=$(CURDIR)/.bin
-GOLANGCI_LINT_VERSION=v2.1.6
-GOLANGCI_LINT=$(LOCAL_BIN)/golangci-lint
+GO_BIN=$(shell go env GOPATH)/bin
+GOLANGCI_LINT_VERSION=v2.11.4
+GOLANGCI_LINT=$(GO_BIN)/golangci-lint
 
 .PHONY: all build install lint test docs generate setup clean release
 
@@ -21,8 +21,8 @@ install: build
 	chmod +x $(PLUGIN_PATH)/$(BINARY_NAME)_v$(VERSION)
 	@echo "✅ Installed to $(PLUGIN_PATH)"
 
-lint: $(GOLANGCI_LINT)
-	$(GOLANGCI_LINT) run
+lint: setup
+	@$(GOLANGCI_LINT) run
 
 test:
 	TF_ACC=1 go test ./... -v
@@ -33,13 +33,21 @@ generate:
 docs: generate
 	@echo "📚 Docs generated in ./docs"
 
-$(GOLANGCI_LINT):
-	@echo "⏳ Installing golangci-lint $(GOLANGCI_LINT_VERSION) into $(LOCAL_BIN)..."
-	@mkdir -p $(LOCAL_BIN)
-	@GOBIN=$(LOCAL_BIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
-
-setup: $(GOLANGCI_LINT)
+setup:
+	@mkdir -p "$(GO_BIN)"
+	@if [ ! -x "$(GOLANGCI_LINT)" ] || ! "$(GOLANGCI_LINT)" --version | grep -q "version $(patsubst v%,%,$(GOLANGCI_LINT_VERSION))"; then \
+		echo "⏳ Installing golangci-lint $(GOLANGCI_LINT_VERSION) into $(GO_BIN)..."; \
+		if command -v curl >/dev/null 2>&1; then \
+			curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b "$(GO_BIN)" "$(GOLANGCI_LINT_VERSION)"; \
+		elif command -v wget >/dev/null 2>&1; then \
+			wget -O- -nv https://golangci-lint.run/install.sh | sh -s -- -b "$(GO_BIN)" "$(GOLANGCI_LINT_VERSION)"; \
+		else \
+			echo "curl or wget is required to install golangci-lint"; \
+			exit 1; \
+		fi; \
+	fi
 	@echo "🔍 Using golangci-lint from $(GOLANGCI_LINT)"
+	@$(GOLANGCI_LINT) --version
 	@echo "✅ Setup complete."
 
 

--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ output "user_id" {
 }
 ```
 
+- Looks up users by **exact** email match
+- Returns only **active, non-deleted** Passbolt users
 - Returns `user id`, `role`, `first_name`, and `last_name`
 - Can be used to assign managers in `passbolt_group`, or resolve dependencies
 

--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -3,12 +3,12 @@
 page_title: "passbolt_user Data Source - passbolt"
 subcategory: ""
 description: |-
-  
+  Looks up an existing active Passbolt user by exact username (email address).
 ---
 
 # passbolt_user (Data Source)
 
-
+Looks up an existing active Passbolt user by exact username (email address).
 
 ## Example Usage
 
@@ -47,7 +47,7 @@ resource "passbolt_folder_permission" "dev_access" {
 
 ### Required
 
-- `username` (String) Username (email address) to look up.
+- `username` (String) Exact username (email address) to look up. The user must already be active in Passbolt.
 
 ### Read-Only
 

--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -3,12 +3,12 @@
 page_title: "passbolt_user Data Source - passbolt"
 subcategory: ""
 description: |-
-  Looks up an existing active Passbolt user by exact username (email address).
+  Looks up an existing active, non-deleted Passbolt user by exact username (email address).
 ---
 
 # passbolt_user (Data Source)
 
-Looks up an existing active Passbolt user by exact username (email address).
+Looks up an existing active, non-deleted Passbolt user by exact username (email address).
 
 ## Example Usage
 
@@ -19,7 +19,7 @@ provider "passbolt" {
   passphrase  = "mysecurepassphrase"
 }
 
-# 🔍 Lookup an existing user by email (must be active in Passbolt)
+# 🔍 Lookup an existing user by exact email (must be active and not deleted in Passbolt)
 data "passbolt_user" "lead" {
   username = "lead.dev@example.com"
 }
@@ -47,7 +47,7 @@ resource "passbolt_folder_permission" "dev_access" {
 
 ### Required
 
-- `username` (String) Exact username (email address) to look up. The user must already be active in Passbolt.
+- `username` (String) Exact username (email address) to look up. The user must already be active and not deleted in Passbolt.
 
 ### Read-Only
 

--- a/examples/data-sources/passbolt_user/data-source.tf
+++ b/examples/data-sources/passbolt_user/data-source.tf
@@ -4,7 +4,7 @@ provider "passbolt" {
   passphrase  = "mysecurepassphrase"
 }
 
-# 🔍 Lookup an existing user by email (must be active in Passbolt)
+# 🔍 Lookup an existing user by exact email (must be active and not deleted in Passbolt)
 data "passbolt_user" "lead" {
   username = "lead.dev@example.com"
 }

--- a/internal/provider/folder_reference.go
+++ b/internal/provider/folder_reference.go
@@ -220,7 +220,7 @@ func normalizeFolderReferenceValue(rawValue string) (string, error) {
 }
 
 func hasRelativePathSegments(value string) bool {
-	for _, segment := range strings.Split(value, "/") {
+	for segment := range strings.SplitSeq(value, "/") {
 		if segment == "." || segment == ".." {
 			return true
 		}

--- a/internal/provider/password_resource_test.go
+++ b/internal/provider/password_resource_test.go
@@ -164,12 +164,12 @@ func testPasswordWithShareGroupsConfig(
 	var groupResources strings.Builder
 	groupNames := ""
 	for i, g := range groups {
-		groupResources.WriteString(fmt.Sprintf(`
+		_, _ = fmt.Fprintf(&groupResources, `
 resource "passbolt_group" "g%d" {
   name     = "%s"
   managers = ["%s"]
 }
-`, i, g, managerID))
+`, i, g, managerID)
 		groupNames += fmt.Sprintf(`passbolt_group.g%d.name,`, i)
 	}
 	groupNames = groupNames[:len(groupNames)-1] // trim last comma

--- a/internal/provider/password_resource_test.go
+++ b/internal/provider/password_resource_test.go
@@ -3,6 +3,7 @@ package provider_test
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -160,15 +161,15 @@ func testPasswordWithShareGroupsConfig(
 	password string,
 	groups []string,
 ) string {
-	groupResources := ""
+	var groupResources strings.Builder
 	groupNames := ""
 	for i, g := range groups {
-		groupResources += fmt.Sprintf(`
+		groupResources.WriteString(fmt.Sprintf(`
 resource "passbolt_group" "g%d" {
   name     = "%s"
   managers = ["%s"]
 }
-`, i, g, managerID)
+`, i, g, managerID))
 		groupNames += fmt.Sprintf(`passbolt_group.g%d.name,`, i)
 	}
 	groupNames = groupNames[:len(groupNames)-1] // trim last comma
@@ -191,7 +192,7 @@ resource "passbolt_password" "shared" {
   password      = "%s"
   share_groups  = [%s]
 }
-`, baseURL, privateKey, passphrase, groupResources, name, username, uri, password, groupNames)
+`, baseURL, privateKey, passphrase, groupResources.String(), name, username, uri, password, groupNames)
 }
 
 func testPasswordWithShareConfig(

--- a/internal/provider/user_data_source.go
+++ b/internal/provider/user_data_source.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"terraform-provider-passbolt/tools"
 
@@ -61,10 +62,11 @@ func (d *userDataSource) Metadata(_ context.Context,
 
 func (d *userDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		Description: "Looks up an existing active Passbolt user by exact username (email address).",
 		Attributes: map[string]schema.Attribute{
 			"username": schema.StringAttribute{
 				Required:    true,
-				Description: "Username (email address) to look up.",
+				Description: "Exact username (email address) to look up. The user must already be active in Passbolt.",
 			},
 			"id": schema.StringAttribute{
 				Computed:    true,
@@ -96,7 +98,7 @@ func (d *userDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	users, err := d.client.Client.GetUsers(ctx, &api.GetUsersOptions{
 		FilterSearch: config.Username.ValueString(),
 	})
-	if err != nil || len(users) == 0 {
+	if err != nil {
 		resp.Diagnostics.AddError("User not found",
 			fmt.Sprintf("Could not find user with username: %s",
 				config.Username.ValueString()))
@@ -104,15 +106,60 @@ func (d *userDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		return
 	}
 
-	user := users[0]
+	user, err := activeUserByUsername(users, config.Username.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("User not found", err.Error())
+
+		return
+	}
 
 	data := userDataSourceModel{
 		ID:        types.StringValue(user.ID),
 		Username:  types.StringValue(user.Username),
-		Role:      types.StringValue(user.Role.Name),
-		FirstName: types.StringValue(user.Profile.FirstName),
-		LastName:  types.StringValue(user.Profile.LastName),
+		Role:      types.StringValue(userRoleName(user)),
+		FirstName: types.StringValue(userFirstName(user)),
+		LastName:  types.StringValue(userLastName(user)),
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func activeUserByUsername(users []api.User, username string) (*api.User, error) {
+	for _, user := range users {
+		if !strings.EqualFold(user.Username, username) {
+			continue
+		}
+
+		if !user.Active {
+			return nil, fmt.Errorf("user %s exists but is not active in Passbolt", username)
+		}
+
+		return &user, nil
+	}
+
+	return nil, fmt.Errorf("could not find active Passbolt user with username: %s", username)
+}
+
+func userRoleName(user *api.User) string {
+	if user.Role == nil {
+		return ""
+	}
+
+	return user.Role.Name
+}
+
+func userFirstName(user *api.User) string {
+	if user.Profile == nil {
+		return ""
+	}
+
+	return user.Profile.FirstName
+}
+
+func userLastName(user *api.User) string {
+	if user.Profile == nil {
+		return ""
+	}
+
+	return user.Profile.LastName
 }

--- a/internal/provider/user_data_source.go
+++ b/internal/provider/user_data_source.go
@@ -126,20 +126,35 @@ func (d *userDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 }
 
 func activeUserByUsername(users []api.User, username string) (*api.User, error) {
+	var sawDeleted bool
+	var sawInactive bool
+
 	for _, user := range users {
 		if !strings.EqualFold(user.Username, username) {
 			continue
 		}
 
 		if user.Deleted {
-			return nil, fmt.Errorf("user %s exists in Passbolt but is deleted", username)
+			sawDeleted = true
+
+			continue
 		}
 
 		if !user.Active {
-			return nil, fmt.Errorf("user %s exists but is not active in Passbolt", username)
+			sawInactive = true
+
+			continue
 		}
 
 		return &user, nil
+	}
+
+	if sawDeleted {
+		return nil, fmt.Errorf("user %s exists in Passbolt but is deleted", username)
+	}
+
+	if sawInactive {
+		return nil, fmt.Errorf("user %s exists but is not active in Passbolt", username)
 	}
 
 	return nil, fmt.Errorf("could not find active Passbolt user with username: %s", username)

--- a/internal/provider/user_data_source.go
+++ b/internal/provider/user_data_source.go
@@ -62,11 +62,12 @@ func (d *userDataSource) Metadata(_ context.Context,
 
 func (d *userDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Looks up an existing active Passbolt user by exact username (email address).",
+		Description: "Looks up an existing active, non-deleted Passbolt user by exact username (email address).",
 		Attributes: map[string]schema.Attribute{
 			"username": schema.StringAttribute{
-				Required:    true,
-				Description: "Exact username (email address) to look up. The user must already be active in Passbolt.",
+				Required: true,
+				Description: "Exact username (email address) to look up. " +
+					"The user must already be active and not deleted in Passbolt.",
 			},
 			"id": schema.StringAttribute{
 				Computed:    true,
@@ -128,6 +129,10 @@ func activeUserByUsername(users []api.User, username string) (*api.User, error) 
 	for _, user := range users {
 		if !strings.EqualFold(user.Username, username) {
 			continue
+		}
+
+		if user.Deleted {
+			return nil, fmt.Errorf("user %s exists in Passbolt but is deleted", username)
 		}
 
 		if !user.Active {

--- a/internal/provider/user_data_source_internal_test.go
+++ b/internal/provider/user_data_source_internal_test.go
@@ -38,6 +38,14 @@ func TestActiveUserByUsername(t *testing.T) {
 			username: "alexey@example.com",
 			wantErr:  "user alexey@example.com exists but is not active in Passbolt",
 		},
+		"rejects deleted exact match": {
+			users: []api.User{
+				{ID: "wanted", Username: "alexey@example.com", Active: true, Deleted: true},
+				{ID: "other", Username: "alexey+other@example.com", Active: true},
+			},
+			username: "alexey@example.com",
+			wantErr:  "user alexey@example.com exists in Passbolt but is deleted",
+		},
 		"rejects missing exact match": {
 			users: []api.User{
 				{ID: "other", Username: "alexey+other@example.com", Active: true},

--- a/internal/provider/user_data_source_internal_test.go
+++ b/internal/provider/user_data_source_internal_test.go
@@ -1,0 +1,89 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/passbolt/go-passbolt/api"
+)
+
+func TestActiveUserByUsername(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		users    []api.User
+		username string
+		wantID   string
+		wantErr  string
+	}{
+		"returns exact active match": {
+			users: []api.User{
+				{ID: "other", Username: "prefix-alexey@example.com", Active: true},
+				{ID: "wanted", Username: "alexey@example.com", Active: true},
+			},
+			username: "alexey@example.com",
+			wantID:   "wanted",
+		},
+		"matches username case insensitively": {
+			users: []api.User{
+				{ID: "wanted", Username: "Alexey@Example.com", Active: true},
+			},
+			username: "alexey@example.com",
+			wantID:   "wanted",
+		},
+		"rejects inactive exact match": {
+			users: []api.User{
+				{ID: "wanted", Username: "alexey@example.com", Active: false},
+				{ID: "other", Username: "alexey+other@example.com", Active: true},
+			},
+			username: "alexey@example.com",
+			wantErr:  "user alexey@example.com exists but is not active in Passbolt",
+		},
+		"rejects missing exact match": {
+			users: []api.User{
+				{ID: "other", Username: "alexey+other@example.com", Active: true},
+			},
+			username: "alexey@example.com",
+			wantErr:  "could not find active Passbolt user with username: alexey@example.com",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			assertActiveUserByUsername(t, test.users, test.username, test.wantID, test.wantErr)
+		})
+	}
+}
+
+func assertActiveUserByUsername(
+	t *testing.T,
+	users []api.User,
+	username string,
+	wantID string,
+	wantErr string,
+) {
+	t.Helper()
+
+	user, err := activeUserByUsername(users, username)
+	if wantErr != "" {
+		if err == nil {
+			t.Fatalf("expected error %q", wantErr)
+		}
+		if err.Error() != wantErr {
+			t.Fatalf("expected error %q, got %q", wantErr, err.Error())
+		}
+
+		return
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if user == nil {
+		t.Fatal("expected user, got nil")
+	}
+	if user.ID != wantID {
+		t.Fatalf("expected user ID %q, got %q", wantID, user.ID)
+	}
+}

--- a/internal/provider/user_data_source_internal_test.go
+++ b/internal/provider/user_data_source_internal_test.go
@@ -64,6 +64,41 @@ func TestActiveUserByUsername(t *testing.T) {
 	}
 }
 
+func TestActiveUserByUsernamePrefersUsableExactMatch(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		users    []api.User
+		username string
+		wantID   string
+	}{
+		"returns later active exact match after deleted match": {
+			users: []api.User{
+				{ID: "deleted", Username: "alexey@example.com", Active: true, Deleted: true},
+				{ID: "wanted", Username: "alexey@example.com", Active: true},
+			},
+			username: "alexey@example.com",
+			wantID:   "wanted",
+		},
+		"returns later active exact match after inactive match": {
+			users: []api.User{
+				{ID: "inactive", Username: "alexey@example.com", Active: false},
+				{ID: "wanted", Username: "alexey@example.com", Active: true},
+			},
+			username: "alexey@example.com",
+			wantID:   "wanted",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			assertActiveUserByUsername(t, test.users, test.username, test.wantID, "")
+		})
+	}
+}
+
 func assertActiveUserByUsername(
 	t *testing.T,
 	users []api.User,


### PR DESCRIPTION
- `data.passbolt_user` now resolves only exact, active, non-deleted Passbolt users.
- Improved `passbolt_user` data source behavior for deleted or stale Passbolt user records that could previously be returned by search results.