### PR TITLE
fix: preserve secret payloads when adding users to shared groups

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,6 +43,14 @@ jobs:
           go-version: '1.26.2'
           cache: false
 
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_wrapper: false
+
+      - name: Show Terraform version
+        run: terraform version
+
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
@@ -56,37 +64,6 @@ jobs:
 
       - name: Run unit tests
         run: go test ./... -count=1
-
-      - name: Check acceptance test environment
-        env:
-          PASSBOLT_BASE_URL: ${{ vars.PASSBOLT_BASE_URL != '' && vars.PASSBOLT_BASE_URL || secrets.PASSBOLT_BASE_URL }}
-          PASSBOLT_PRIVATE_KEY: ${{ secrets.PASSBOLT_PRIVATE_KEY != '' && secrets.PASSBOLT_PRIVATE_KEY || vars.PASSBOLT_PRIVATE_KEY }}
-          PASSBOLT_PASSPHRASE: ${{ secrets.PASSBOLT_PASSPHRASE != '' && secrets.PASSBOLT_PASSPHRASE || vars.PASSBOLT_PASSPHRASE }}
-          PASSBOLT_MANAGER_ID: ${{ vars.PASSBOLT_MANAGER_ID != '' && vars.PASSBOLT_MANAGER_ID || secrets.PASSBOLT_MANAGER_ID }}
-          PASSBOLT_TEST_USER_EMAIL: ${{ vars.PASSBOLT_TEST_USER_EMAIL != '' && vars.PASSBOLT_TEST_USER_EMAIL || secrets.PASSBOLT_TEST_USER_EMAIL }}
-          PASSBOLT_TEST_EMAIL_DOMAIN: ${{ vars.PASSBOLT_TEST_EMAIL_DOMAIN != '' && vars.PASSBOLT_TEST_EMAIL_DOMAIN || secrets.PASSBOLT_TEST_EMAIL_DOMAIN }}
-        run: |
-          missing=0
-          for name in PASSBOLT_BASE_URL PASSBOLT_PRIVATE_KEY PASSBOLT_PASSPHRASE PASSBOLT_MANAGER_ID PASSBOLT_TEST_USER_EMAIL; do
-            if [ -z "${!name}" ]; then
-              echo "Missing required environment variable: $name"
-              missing=1
-            fi
-          done
-          if [ "$missing" -ne 0 ]; then
-            exit 1
-          fi
-
-      - name: Run acceptance tests
-        env:
-          TF_ACC: "1"
-          PASSBOLT_BASE_URL: ${{ vars.PASSBOLT_BASE_URL != '' && vars.PASSBOLT_BASE_URL || secrets.PASSBOLT_BASE_URL }}
-          PASSBOLT_PRIVATE_KEY: ${{ secrets.PASSBOLT_PRIVATE_KEY != '' && secrets.PASSBOLT_PRIVATE_KEY || vars.PASSBOLT_PRIVATE_KEY }}
-          PASSBOLT_PASSPHRASE: ${{ secrets.PASSBOLT_PASSPHRASE != '' && secrets.PASSBOLT_PASSPHRASE || vars.PASSBOLT_PASSPHRASE }}
-          PASSBOLT_MANAGER_ID: ${{ vars.PASSBOLT_MANAGER_ID != '' && vars.PASSBOLT_MANAGER_ID || secrets.PASSBOLT_MANAGER_ID }}
-          PASSBOLT_TEST_USER_EMAIL: ${{ vars.PASSBOLT_TEST_USER_EMAIL != '' && vars.PASSBOLT_TEST_USER_EMAIL || secrets.PASSBOLT_TEST_USER_EMAIL }}
-          PASSBOLT_TEST_EMAIL_DOMAIN: ${{ vars.PASSBOLT_TEST_EMAIL_DOMAIN != '' && vars.PASSBOLT_TEST_EMAIL_DOMAIN || secrets.PASSBOLT_TEST_EMAIL_DOMAIN }}
-        run: go test ./... -count=1 -v
 
       - name: Preview version bump (dry-run)
         id: tag_version

--- a/.github/workflows/notify-and-ci.yml
+++ b/.github/workflows/notify-and-ci.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: '1.26.2'
-          cache: true
+          cache: false
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v4

--- a/.github/workflows/notify-and-ci.yml
+++ b/.github/workflows/notify-and-ci.yml
@@ -47,12 +47,20 @@ jobs:
           go-version: '1.26.2'
           cache: true
 
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_wrapper: false
+
+      - name: Show Terraform version
+        run: terraform version
+
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
           version: v2.11
 
-      - name: Run tests
+      - name: Run acceptance tests
         env:
           TF_ACC: "1"
           PASSBOLT_BASE_URL: ${{ vars.PASSBOLT_BASE_URL != '' && vars.PASSBOLT_BASE_URL || secrets.PASSBOLT_BASE_URL }}
@@ -62,7 +70,7 @@ jobs:
           PASSBOLT_TEST_USER_EMAIL: ${{ vars.PASSBOLT_TEST_USER_EMAIL != '' && vars.PASSBOLT_TEST_USER_EMAIL || secrets.PASSBOLT_TEST_USER_EMAIL }}
           PASSBOLT_TEST_EMAIL_DOMAIN: ${{ vars.PASSBOLT_TEST_EMAIL_DOMAIN != '' && vars.PASSBOLT_TEST_EMAIL_DOMAIN || secrets.PASSBOLT_TEST_EMAIL_DOMAIN }}
         run: |
-          go test ./... -v
+          go test ./... -count=1 -v
 
   notify-success:
     if: ${{ success() && github.event_name == 'pull_request' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.5.6 — 2026-04-21
+
+### 🛠 Fixed
+
+- `passbolt_group` now preserves the decrypted secret payload when re-encrypting secrets for users added to an existing shared group, fixing broken secrets that were visible but not decryptable.
+
 ## v1.5.5 — 2026-04-20
 
 ### 🛠 Fixed

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BINARY_NAME=terraform-provider-passbolt
-VERSION=1.5.5
+VERSION=1.5.6
 OS=$(shell uname | tr A-Z a-z)
 ARCH=amd64
 PLUGIN_NAMESPACE=bald1nh0

--- a/README.md
+++ b/README.md
@@ -337,6 +337,10 @@ output "db_admin_password" {
   - `PASSBOLT_TEST_USER_EMAIL`
   - `PASSBOLT_TEST_EMAIL_DOMAIN` (optional; defaults to `example.com` for generated acceptance-test users)
   - `PASSBOLT_MEMBER_ID` (optional; must be different from `PASSBOLT_MANAGER_ID`)
+  - `PASSBOLT_DECRYPT_TEST_USER_EMAIL` (optional; dedicated user for decrypt-after-group-update acceptance coverage)
+  - `PASSBOLT_DECRYPT_TEST_USER_ID` (optional; dedicated user UUID for decrypt-after-group-update acceptance coverage)
+  - `PASSBOLT_DECRYPT_TEST_USER_PRIVATE_KEY` (optional; dedicated user private key for decrypt-after-group-update acceptance coverage)
+  - `PASSBOLT_DECRYPT_TEST_USER_PASSPHRASE` (optional; dedicated user passphrase for decrypt-after-group-update acceptance coverage)
 
 ---
 

--- a/internal/provider/group_resource_manual_test.go
+++ b/internal/provider/group_resource_manual_test.go
@@ -13,8 +13,6 @@ import (
 )
 
 func TestManualPassboltGroupAddMemberToSharedGroupApplyForGUI(t *testing.T) {
-	t.Parallel()
-
 	requireAcceptanceEnv(t, "PASSBOLT_BASE_URL", "PASSBOLT_PRIVATE_KEY", "PASSBOLT_PASSPHRASE")
 
 	baseURL := os.Getenv("PASSBOLT_BASE_URL")
@@ -54,8 +52,6 @@ func TestManualPassboltGroupAddMemberToSharedGroupApplyForGUI(t *testing.T) {
 }
 
 func TestManualPassboltGroupAddMemberToSharedGroupDestroyForGUI(t *testing.T) {
-	t.Parallel()
-
 	workdir := manualGUIWorkdir(t, manualGUIRunID(t))
 	if _, err := os.Stat(filepath.Join(workdir, "terraform.tfstate")); err != nil {
 		t.Fatalf("manual GUI state not found in %s: %v", workdir, err)

--- a/internal/provider/group_resource_manual_test.go
+++ b/internal/provider/group_resource_manual_test.go
@@ -1,0 +1,185 @@
+//go:build manualgui
+
+package provider_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestManualPassboltGroupAddMemberToSharedGroupApplyForGUI(t *testing.T) {
+	t.Parallel()
+
+	requireAcceptanceEnv(t, "PASSBOLT_BASE_URL", "PASSBOLT_PRIVATE_KEY", "PASSBOLT_PASSPHRASE")
+
+	baseURL := os.Getenv("PASSBOLT_BASE_URL")
+	privateKey := os.Getenv("PASSBOLT_PRIVATE_KEY")
+	passphrase := os.Getenv("PASSBOLT_PASSPHRASE")
+	managerID := testAccCurrentUserID(t, baseURL, privateKey, passphrase)
+	memberID := testAccDecryptGroupMemberID(t, baseURL, privateKey, passphrase, managerID)
+	runID := manualGUIRunID(t)
+	workdir := manualGUIWorkdir(t, runID)
+	groupName := fmt.Sprintf("manual-gui-group-%s", runID)
+	passwordName := fmt.Sprintf("manual-gui-secret-%s", runID)
+
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatalf("failed to create manual GUI workdir: %v", err)
+	}
+
+	writeManualGUIConfig(
+		t,
+		workdir,
+		manualGUIConfig(baseURL, privateKey, passphrase, managerID, memberID, groupName, passwordName, false),
+	)
+	runTerraform(t, workdir, "init", "-input=false")
+	runTerraform(t, workdir, "apply", "-auto-approve", "-input=false")
+
+	writeManualGUIConfig(
+		t,
+		workdir,
+		manualGUIConfig(baseURL, privateKey, passphrase, managerID, memberID, groupName, passwordName, true),
+	)
+	runTerraform(t, workdir, "apply", "-auto-approve", "-input=false")
+
+	output := runTerraform(t, workdir, "output")
+	t.Logf("Manual GUI verification is ready in %s", workdir)
+	t.Logf("Terraform outputs:\n%s", output)
+	t.Logf("Open Passbolt UI and verify whether user %s can decrypt secret %q in group %q", memberID, passwordName, groupName)
+	t.Log("Run the destroy test with the same PASSBOLT_MANUAL_GUI_RUN_ID after verification.")
+}
+
+func TestManualPassboltGroupAddMemberToSharedGroupDestroyForGUI(t *testing.T) {
+	t.Parallel()
+
+	workdir := manualGUIWorkdir(t, manualGUIRunID(t))
+	if _, err := os.Stat(filepath.Join(workdir, "terraform.tfstate")); err != nil {
+		t.Fatalf("manual GUI state not found in %s: %v", workdir, err)
+	}
+
+	runTerraform(t, workdir, "destroy", "-auto-approve", "-input=false")
+	t.Logf("Manual GUI resources destroyed from %s", workdir)
+}
+
+func manualGUIRunID(t *testing.T) string {
+	t.Helper()
+
+	runID := strings.TrimSpace(os.Getenv("PASSBOLT_MANUAL_GUI_RUN_ID"))
+	if runID == "" {
+		t.Skip("PASSBOLT_MANUAL_GUI_RUN_ID is required for manual GUI tests")
+	}
+
+	return runID
+}
+
+func manualGUIWorkdir(t *testing.T, runID string) string {
+	t.Helper()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current working directory: %v", err)
+	}
+
+	repoRoot := filepath.Clean(filepath.Join(cwd, "..", ".."))
+	return filepath.Join(repoRoot, ".tmp", "manual-gui", runID)
+}
+
+func writeManualGUIConfig(t *testing.T, workdir, config string) {
+	t.Helper()
+
+	configPath := filepath.Join(workdir, "main.tf")
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatalf("failed to write manual GUI config: %v", err)
+	}
+}
+
+func runTerraform(t *testing.T, workdir string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command("terraform", args...)
+	cmd.Dir = workdir
+	cmd.Env = os.Environ()
+
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("terraform %s failed:\n%s\nerror: %v", strings.Join(args, " "), output.String(), err)
+	}
+
+	return output.String()
+}
+
+func manualGUIConfig(
+	baseURL,
+	privateKey,
+	passphrase,
+	managerID,
+	memberID,
+	groupName,
+	passwordName string,
+	includeMember bool,
+) string {
+	members := ""
+	if includeMember {
+		members = fmt.Sprintf(`
+  members  = ["%s"]`, memberID)
+	}
+
+	return fmt.Sprintf(`
+terraform {
+  required_providers {
+    passbolt = {
+      source = "Bald1nh0/passbolt"
+    }
+  }
+}
+
+provider "passbolt" {
+  base_url    = "%s"
+  private_key = <<EOF
+%s
+EOF
+  passphrase  = "%s"
+}
+
+resource "passbolt_group" "manual" {
+  name     = "%s"
+  managers = ["%s"]%s
+}
+
+resource "passbolt_password" "manual" {
+  name         = "%s"
+  username     = "manual-gui-user"
+  uri          = "https://manual-gui.example.com"
+  password     = "manual-gui-secret"
+  description  = "Manual GUI verification secret"
+  share_groups = [passbolt_group.manual.name]
+}
+
+output "group_id" {
+  value = passbolt_group.manual.id
+}
+
+output "group_name" {
+  value = passbolt_group.manual.name
+}
+
+output "password_id" {
+  value = passbolt_password.manual.id
+}
+
+output "password_name" {
+  value = passbolt_password.manual.name
+}
+
+output "member_id" {
+  value = "%s"
+}
+`, baseURL, privateKey, passphrase, groupName, managerID, members, passwordName, memberID)
+}

--- a/internal/provider/group_resource_test.go
+++ b/internal/provider/group_resource_test.go
@@ -8,7 +8,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/passbolt/go-passbolt/api"
+	"github.com/passbolt/go-passbolt/helper"
 )
 
 func TestAccPassboltGroup_fullLifecycle(t *testing.T) {
@@ -93,6 +95,46 @@ func TestAccPassboltGroup_addMemberToSharedGroup(t *testing.T) {
 	})
 }
 
+func TestAccPassboltGroup_addMemberToSharedGroupCanDecryptSecret(t *testing.T) {
+	t.Parallel()
+
+	requireAcceptanceEnv(
+		t,
+		"PASSBOLT_BASE_URL",
+		"PASSBOLT_PRIVATE_KEY",
+		"PASSBOLT_PASSPHRASE",
+	)
+
+	baseURL := os.Getenv("PASSBOLT_BASE_URL")
+	privateKey := os.Getenv("PASSBOLT_PRIVATE_KEY")
+	passphrase := os.Getenv("PASSBOLT_PASSPHRASE")
+	memberPrivateKey := testAccDecryptUserPrivateKey(t)
+	memberPassphrase := testAccDecryptUserPassphrase(t)
+	managerID := testAccCurrentUserID(t, baseURL, privateKey, passphrase)
+	memberID := testAccDecryptGroupMemberID(t, baseURL, privateKey, passphrase, managerID)
+	suffix := testAccSuffix()
+	groupName := testAccName("test-group-shared-decrypt", suffix)
+	passwordName := testAccName("test-password-shared-decrypt", suffix)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			testStepCreateSharedGroupPassword(baseURL, privateKey, passphrase, managerID, groupName, passwordName),
+			testStepAddMemberToSharedGroupAndDecrypt(
+				baseURL,
+				privateKey,
+				passphrase,
+				memberPrivateKey,
+				memberPassphrase,
+				managerID,
+				memberID,
+				groupName,
+				passwordName,
+			),
+		},
+	})
+}
+
 func testAccGroupMemberID(t *testing.T, baseURL, privateKey, passphrase, managerID string) string {
 	t.Helper()
 
@@ -138,6 +180,87 @@ func testAccGroupMemberID(t *testing.T, baseURL, privateKey, passphrase, manager
 	}
 
 	return memberID
+}
+
+func testAccDecryptGroupMemberID(t *testing.T, baseURL, privateKey, passphrase, managerID string) string {
+	t.Helper()
+
+	memberID := os.Getenv("PASSBOLT_DECRYPT_TEST_USER_ID")
+	if memberID != "" {
+		if memberID == managerID {
+			t.Skip("PASSBOLT_DECRYPT_TEST_USER_ID must be different from PASSBOLT_MANAGER_ID")
+		}
+
+		return memberID
+	}
+
+	memberEmail := os.Getenv("PASSBOLT_DECRYPT_TEST_USER_EMAIL")
+	if memberEmail == "" {
+		return testAccGroupMemberID(t, baseURL, privateKey, passphrase, managerID)
+	}
+
+	ctx := context.Background()
+	client, err := api.NewClient(nil, "", baseURL, privateKey, passphrase)
+	if err != nil {
+		t.Fatalf("failed to create Passbolt API client: %v", err)
+	}
+	if err := client.Login(ctx); err != nil {
+		t.Fatalf("failed to log in to Passbolt API: %v", err)
+	}
+	defer func() {
+		_ = client.Logout(ctx)
+	}()
+
+	users, err := client.GetUsers(ctx, &api.GetUsersOptions{
+		FilterSearch: memberEmail,
+	})
+	if err != nil {
+		t.Fatalf("failed to look up decrypt test user %q: %v", memberEmail, err)
+	}
+	if len(users) == 0 {
+		t.Skipf("PASSBOLT_DECRYPT_TEST_USER_EMAIL %q did not match any user", memberEmail)
+	}
+
+	memberID = users[0].ID
+	if memberID == managerID {
+		t.Skip("PASSBOLT_DECRYPT_TEST_USER_EMAIL resolves to PASSBOLT_MANAGER_ID; skipping decrypt acceptance test")
+	}
+
+	return memberID
+}
+
+func testAccDecryptUserPrivateKey(t *testing.T) string {
+	t.Helper()
+
+	privateKey := os.Getenv("PASSBOLT_DECRYPT_TEST_USER_PRIVATE_KEY")
+	if privateKey != "" {
+		return privateKey
+	}
+
+	privateKey = os.Getenv("PASSBOLT_MEMBER_PRIVATE_KEY")
+	if privateKey == "" {
+		t.Skip(
+			"PASSBOLT_DECRYPT_TEST_USER_PRIVATE_KEY or PASSBOLT_MEMBER_PRIVATE_KEY is required for decrypt acceptance tests",
+		)
+	}
+
+	return privateKey
+}
+
+func testAccDecryptUserPassphrase(t *testing.T) string {
+	t.Helper()
+
+	passphrase := os.Getenv("PASSBOLT_DECRYPT_TEST_USER_PASSPHRASE")
+	if passphrase != "" {
+		return passphrase
+	}
+
+	passphrase = os.Getenv("PASSBOLT_MEMBER_PASSPHRASE")
+	if passphrase == "" {
+		t.Skip("PASSBOLT_DECRYPT_TEST_USER_PASSPHRASE or PASSBOLT_MEMBER_PASSPHRASE is required for decrypt acceptance tests")
+	}
+
+	return passphrase
 }
 
 func testAccCurrentUserID(t *testing.T, baseURL, privateKey, passphrase string) string {
@@ -307,6 +430,37 @@ func testStepAddMemberToSharedGroup(
 	}
 }
 
+func testStepAddMemberToSharedGroupAndDecrypt(
+	baseURL,
+	privateKey,
+	passphrase,
+	memberPrivateKey,
+	memberPassphrase,
+	managerID,
+	memberID,
+	groupName,
+	passwordName string,
+) resource.TestStep {
+	return resource.TestStep{
+		Config: testGroupWithSharedPasswordConfig(
+			baseURL,
+			privateKey,
+			passphrase,
+			managerID,
+			memberID,
+			groupName,
+			passwordName,
+		),
+		Check: resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr("passbolt_group.test", "name", groupName),
+			resource.TestCheckResourceAttr("passbolt_group.test", "managers.#", "1"),
+			resource.TestCheckResourceAttr("passbolt_group.test", "members.#", "1"),
+			resource.TestCheckResourceAttr("passbolt_password.shared", "name", passwordName),
+			testCheckSharedPasswordDecryptableAsMember(baseURL, memberPrivateKey, memberPassphrase, passwordName),
+		),
+	}
+}
+
 func testStepNoDriftSharedGroupMember(
 	baseURL,
 	privateKey,
@@ -399,4 +553,55 @@ resource "passbolt_password" "shared" {
   share_groups = [passbolt_group.test.name]
 }
 `, baseURL, privateKey, passphrase, groupName, managerID, members, passwordName)
+}
+
+func testCheckSharedPasswordDecryptableAsMember(
+	baseURL,
+	memberPrivateKey,
+	memberPassphrase,
+	passwordName string,
+) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		resourceState, ok := state.RootModule().Resources["passbolt_password.shared"]
+		if !ok {
+			return fmt.Errorf("passbolt_password.shared not found in Terraform state")
+		}
+
+		resourceID := resourceState.Primary.ID
+		if resourceID == "" {
+			return fmt.Errorf("passbolt_password.shared id is empty")
+		}
+
+		ctx := context.Background()
+		client, err := api.NewClient(nil, "", baseURL, memberPrivateKey, memberPassphrase)
+		if err != nil {
+			return fmt.Errorf("failed to create Passbolt API client for member: %w", err)
+		}
+		if err := client.Login(ctx); err != nil {
+			return fmt.Errorf("failed to log in as shared-group member: %w", err)
+		}
+		defer func() {
+			_ = client.Logout(ctx)
+		}()
+
+		_, name, username, uri, password, _, err := helper.GetResource(ctx, client, resourceID)
+		if err != nil {
+			return fmt.Errorf("failed to decrypt shared resource %s as member: %w", resourceID, err)
+		}
+
+		if name != passwordName {
+			return fmt.Errorf("expected shared resource name %q, got %q", passwordName, name)
+		}
+		if username != "shared-user" {
+			return fmt.Errorf("expected shared resource username %q, got %q", "shared-user", username)
+		}
+		if uri != "https://shared-group.example.com" {
+			return fmt.Errorf("expected shared resource uri %q, got %q", "https://shared-group.example.com", uri)
+		}
+		if password != "shared-secret" {
+			return fmt.Errorf("expected shared resource password %q, got %q", "shared-secret", password)
+		}
+
+		return nil
+	}
 }

--- a/internal/provider/group_update.go
+++ b/internal/provider/group_update.go
@@ -170,24 +170,19 @@ func appendMissingGroupSecrets(
 		return fmt.Errorf("getting users: %w", err)
 	}
 
-	secrets := flattenGroupSecrets(dryRun.DryRun.Secrets)
 	decryptedSecretCache := map[string]string{}
-	currentUserID := client.GetUserID()
 
 	for _, container := range dryRun.DryRun.SecretsNeeded {
 		missingSecret := container.Secret
-		decryptedSecret, ok := decryptedSecretCache[missingSecret.ResourceID]
-		if !ok {
-			decryptedSecret, err := decryptedGroupSecretByResourceID(
-				secrets,
-				missingSecret.ResourceID,
-				currentUserID,
-				client.DecryptMessage,
-			)
-			if err != nil {
-				return fmt.Errorf("decrypting secret: %w", err)
-			}
-			decryptedSecretCache[missingSecret.ResourceID] = decryptedSecret
+		decryptedSecret, err := cachedDecryptedSecret(
+			decryptedSecretCache,
+			missingSecret.ResourceID,
+			func(resourceID string) (string, error) {
+				return currentUserDecryptedSecretByResourceID(ctx, client, resourceID)
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("decrypting secret: %w", err)
 		}
 
 		publicKey, err := groupUserPublicKey(missingSecret.UserID, users)
@@ -208,6 +203,46 @@ func appendMissingGroupSecrets(
 	}
 
 	return nil
+}
+
+func cachedDecryptedSecret(
+	cache map[string]string,
+	resourceID string,
+	load func(resourceID string) (string, error),
+) (string, error) {
+	if decryptedSecret, ok := cache[resourceID]; ok {
+		return decryptedSecret, nil
+	}
+
+	decryptedSecret, err := load(resourceID)
+	if err != nil {
+		return "", err
+	}
+	cache[resourceID] = decryptedSecret
+
+	return decryptedSecret, nil
+}
+
+func currentUserDecryptedSecretByResourceID(
+	ctx context.Context,
+	client *api.Client,
+	resourceID string,
+) (string, error) {
+	secret, err := client.GetSecret(ctx, resourceID)
+	if err != nil {
+		return "", fmt.Errorf("get current user secret for resource %v: %w", resourceID, err)
+	}
+
+	decryptedSecret, err := client.DecryptMessage(secret.Data)
+	if err != nil {
+		return "", fmt.Errorf("decrypt current user secret for resource %v: %w", resourceID, err)
+	}
+
+	if decryptedSecret == "" {
+		return "", fmt.Errorf("decrypted current user secret for resource %v is empty", resourceID)
+	}
+
+	return decryptedSecret, nil
 }
 
 func saveGroupUpdate(
@@ -270,15 +305,6 @@ func verifyGroupMembershipOperations(
 	return nil
 }
 
-func flattenGroupSecrets(containers []api.GroupSecret) []api.Secret {
-	secrets := []api.Secret{}
-	for _, container := range containers {
-		secrets = append(secrets, container.Secret...)
-	}
-
-	return secrets
-}
-
 func groupMembershipByUserID(
 	memberships []api.GroupMembership,
 	userID string,
@@ -290,62 +316,6 @@ func groupMembershipByUserID(
 	}
 
 	return nil, fmt.Errorf("cannot find membership for user ID %v", userID)
-}
-
-func decryptedGroupSecretByResourceID(
-	secrets []api.Secret,
-	resourceID,
-	currentUserID string,
-	decrypt func(string) (string, error),
-) (string, error) {
-	candidates := groupSecretsByResourceID(secrets, resourceID)
-	if len(candidates) == 0 {
-		return "", fmt.Errorf("cannot find secret for resource ID %v", resourceID)
-	}
-
-	tryDecrypt := func(secret api.Secret) (string, bool) {
-		decryptedSecret, err := decrypt(secret.Data)
-		if err != nil {
-			return "", false
-		}
-
-		return decryptedSecret, true
-	}
-
-	if currentUserID != "" {
-		for _, secret := range candidates {
-			if secret.UserID != currentUserID {
-				continue
-			}
-
-			if decryptedSecret, ok := tryDecrypt(secret); ok {
-				return decryptedSecret, nil
-			}
-		}
-	}
-
-	for _, secret := range candidates {
-		if secret.UserID == currentUserID {
-			continue
-		}
-
-		if decryptedSecret, ok := tryDecrypt(secret); ok {
-			return decryptedSecret, nil
-		}
-	}
-
-	return "", fmt.Errorf("cannot decrypt secret for resource ID %v", resourceID)
-}
-
-func groupSecretsByResourceID(secrets []api.Secret, resourceID string) []api.Secret {
-	matches := make([]api.Secret, 0)
-	for _, secret := range secrets {
-		if secret.ResourceID == resourceID {
-			matches = append(matches, secret)
-		}
-	}
-
-	return matches
 }
 
 func groupUserPublicKey(userID string, users []api.User) (string, error) {

--- a/internal/provider/group_update_internal_test.go
+++ b/internal/provider/group_update_internal_test.go
@@ -1,102 +1,71 @@
 package provider
 
 import (
-	"fmt"
+	"errors"
 	"testing"
-
-	"github.com/passbolt/go-passbolt/api"
 )
 
-func TestDecryptedGroupSecretByResourceIDPrefersCurrentUser(t *testing.T) {
+func TestCachedDecryptedSecretReturnsLoadedValueOnCacheMiss(t *testing.T) {
 	t.Parallel()
 
-	got, err := decryptedGroupSecretByResourceID(
-		[]api.Secret{
-			{UserID: "other-user", ResourceID: "resource-1", Data: "other-secret"},
-			{UserID: "current-user", ResourceID: "resource-1", Data: "current-secret"},
-		},
-		"resource-1",
-		"current-user",
-		testDecryptResults(map[string]string{
-			"other-secret":   "other-data",
-			"current-secret": "current-data",
-		}),
-	)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got != "current-data" {
-		t.Fatalf("expected decrypted secret %q, got %q", "current-data", got)
-	}
-}
+	cache := map[string]string{}
+	loadCalls := 0
 
-func TestDecryptedGroupSecretByResourceIDFallsBackToDecryptableMatch(t *testing.T) {
-	t.Parallel()
-
-	got, err := decryptedGroupSecretByResourceID(
-		[]api.Secret{
-			{UserID: "current-user", ResourceID: "resource-1", Data: "broken-secret"},
-			{UserID: "other-user", ResourceID: "resource-1", Data: "other-secret"},
-		},
-		"resource-1",
-		"current-user",
-		testDecryptResults(map[string]string{
-			"other-secret": "other-data",
-		}),
-	)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got != "other-data" {
-		t.Fatalf("expected decrypted secret %q, got %q", "other-data", got)
-	}
-}
-
-func TestDecryptedGroupSecretByResourceIDReturnsErrorWhenNoMatchExists(t *testing.T) {
-	t.Parallel()
-
-	_, err := decryptedGroupSecretByResourceID(
-		[]api.Secret{
-			{UserID: "current-user", ResourceID: "resource-1", Data: "current-secret"},
-		},
-		"resource-2",
-		"current-user",
-		testDecryptResults(map[string]string{}),
-	)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if err.Error() != "cannot find secret for resource ID resource-2" {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestDecryptedGroupSecretByResourceIDReturnsErrorWhenNothingDecrypts(t *testing.T) {
-	t.Parallel()
-
-	_, err := decryptedGroupSecretByResourceID(
-		[]api.Secret{
-			{UserID: "current-user", ResourceID: "resource-1", Data: "broken-secret"},
-			{UserID: "other-user", ResourceID: "resource-1", Data: "other-broken-secret"},
-		},
-		"resource-1",
-		"current-user",
-		testDecryptResults(map[string]string{}),
-	)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if err.Error() != "cannot decrypt secret for resource ID resource-1" {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func testDecryptResults(results map[string]string) func(string) (string, error) {
-	return func(data string) (string, error) {
-		if decrypted, ok := results[data]; ok {
-			return decrypted, nil
+	got, err := cachedDecryptedSecret(cache, "resource-1", func(resourceID string) (string, error) {
+		loadCalls++
+		if resourceID != "resource-1" {
+			t.Fatalf("expected resource-1, got %s", resourceID)
 		}
 
-		return "", fmt.Errorf("cannot decrypt %s", data)
+		return "plaintext", nil
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got != "plaintext" {
+		t.Fatalf("expected plaintext, got %q", got)
+	}
+	if loadCalls != 1 {
+		t.Fatalf("expected loader to be called once, got %d", loadCalls)
+	}
+	if cache["resource-1"] != "plaintext" {
+		t.Fatalf("expected cache to store plaintext, got %q", cache["resource-1"])
+	}
+}
+
+func TestCachedDecryptedSecretReturnsCachedValue(t *testing.T) {
+	t.Parallel()
+
+	cache := map[string]string{
+		"resource-1": "cached-plaintext",
+	}
+
+	got, err := cachedDecryptedSecret(cache, "resource-1", func(resourceID string) (string, error) {
+		t.Fatalf("loader should not be called for cached resource %s", resourceID)
+
+		return "", nil
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got != "cached-plaintext" {
+		t.Fatalf("expected cached-plaintext, got %q", got)
+	}
+}
+
+func TestCachedDecryptedSecretReturnsLoaderError(t *testing.T) {
+	t.Parallel()
+
+	cache := map[string]string{}
+	expectedErr := errors.New("boom")
+
+	_, err := cachedDecryptedSecret(cache, "resource-1", func(_ string) (string, error) {
+		return "", expectedErr
+	})
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected %v, got %v", expectedErr, err)
+	}
+	if _, ok := cache["resource-1"]; ok {
+		t.Fatal("expected cache to stay empty on loader error")
 	}
 }


### PR DESCRIPTION
## Changes

- fixed `passbolt_group` secret re-encryption when adding users to an existing group with already shared resources
- removed a cache-miss bug in the group update flow that could encrypt an empty plaintext for newly added users
- added unit coverage for decrypted-secret cache behavior
- added acceptance coverage that verifies a user added after group creation can actually decrypt the shared secret
- added a manual GUI verification test under the `manualgui` build tag
- documented the dedicated decrypt-test acceptance environment variables
- updated the changelog for `v1.5.6`