### PR TITLE
feat: add ignore_inactive_members for passbolt_group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.7.0 — 2026-04-24
+
+### ✨ Added
+
+- `passbolt_group.ignore_inactive_members` to skip inactive regular members with a warning and retry them on later applies after activation.
+
 ## v1.6.0 — 2026-04-22
 
 ### ✨ Added

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BINARY_NAME=terraform-provider-passbolt
-VERSION=1.6.0
+VERSION=1.7.0
 OS=$(shell uname | tr A-Z a-z)
 ARCH=amd64
 PLUGIN_NAMESPACE=bald1nh0

--- a/README.md
+++ b/README.md
@@ -278,9 +278,10 @@ resource "passbolt_group" "developers" {
 
 ```hcl
 resource "passbolt_group" "example" {
-  name     = "Terraform Group Example"
-  managers = ["2a61bc5d-bbbb-aaaa-cccc-123456789abc"] # Must be active Passbolt user UUID
-  members  = ["3b72cd6e-cccc-bbbb-dddd-23456789abcd"] # Optional regular group members
+  name                    = "Terraform Group Example"
+  managers                = ["2a61bc5d-bbbb-aaaa-cccc-123456789abc"] # Must be active Passbolt user UUID
+  members                 = ["3b72cd6e-cccc-bbbb-dddd-23456789abcd"] # Optional regular group members
+  ignore_inactive_members = true
 }
 ```
 
@@ -288,7 +289,9 @@ Passbolt requires at least one group manager. Regular members can be managed wit
 
 Group memberships require existing active Passbolt users. A user created by `passbolt_user` may not be available for `passbolt_group` membership in the same Terraform apply; create and activate the user first, then reference it from `passbolt_group` in a later apply.
 
-You can look up user UUIDs using `data "passbolt_user"` or manually fetch them from Passbolt.
+If you already know a regular member UUID and want Terraform to keep retrying that membership after the invitation is accepted, set `ignore_inactive_members = true`. Inactive regular members that are already visible to the Passbolt API are skipped with a warning and retried on later applies. Terraform will continue to show that membership as a pending change until the user becomes active. Unknown or deleted user IDs still fail normally. Group managers remain strict and must already be active.
+
+You can look up active user UUIDs using `data "passbolt_user"` or manually fetch them from Passbolt. Note that `data "passbolt_user"` stays strict and returns only active, non-deleted users.
 
 ---
 

--- a/docs/guides/onboarding.md
+++ b/docs/guides/onboarding.md
@@ -25,6 +25,8 @@ resource "passbolt_user" "engineer" {
 
 ~> A newly created user may not be available for `passbolt_group` membership in the same apply. Wait until the invitation is accepted and the user is active.
 
+If you already know the invited user's UUID and want Terraform to keep retrying regular group membership after activation, you can enable `ignore_inactive_members = true` on `passbolt_group`. This skips inactive regular members that are already visible to the Passbolt API with a warning and retries them on later applies. Terraform will continue to show the pending membership change until the user becomes active. Unknown or deleted user IDs still fail normally. Group managers still must already be active.
+
 ## Step 2: Add the Active User to a Group and Shared Folder
 
 ```terraform

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -49,6 +49,7 @@ resource "passbolt_group" "example" {
 
 ### Optional
 
+- `ignore_inactive_members` (Boolean) When true, inactive regular members that are not yet part of the group are skipped with a warning instead of failing the apply. Terraform will continue to plan those memberships until the users become active. Group managers remain strict and must already exist and be active in Passbolt.
 - `members` (Set of String) List of user IDs to assign as regular group members. Users must already exist and be active in Passbolt.
 
 ### Read-Only

--- a/internal/provider/group_resource.go
+++ b/internal/provider/group_resource.go
@@ -228,13 +228,14 @@ func (r *groupResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 	stateManagers, stateMembers := splitGroupMemberships(memberships, true)
+	currentGroupUsers := groupUserValues(stateManagers, stateMembers)
 
 	appliedMembers := resolveGroupMembersForApply(
 		ctx,
 		r.client.Client,
 		plan.IgnoreInactiveMembers.ValueBool(),
 		desiredMembers,
-		stateMembers,
+		currentGroupUsers,
 		&resp.Diagnostics,
 	)
 	if resp.Diagnostics.HasError() {
@@ -578,6 +579,20 @@ func groupUserRoleMap(managers, members []types.String) map[string]bool {
 	}
 
 	return roles
+}
+
+func groupUserValues(userGroups ...[]types.String) []types.String {
+	total := 0
+	for _, users := range userGroups {
+		total += len(users)
+	}
+
+	result := make([]types.String, 0, total)
+	for _, users := range userGroups {
+		result = append(result, users...)
+	}
+
+	return result
 }
 
 func groupUserSet(users []types.String) map[string]bool {

--- a/internal/provider/group_resource.go
+++ b/internal/provider/group_resource.go
@@ -221,7 +221,7 @@ func (r *groupResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
-	_, memberships, err := helper.GetGroup(ctx, r.client.Client, state.ID.ValueString())
+	currentName, memberships, err := helper.GetGroup(ctx, r.client.Client, state.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading group memberships", err.Error())
 
@@ -243,11 +243,13 @@ func (r *groupResource) Update(ctx context.Context, req resource.UpdateRequest, 
 
 	ops := buildGroupMembershipOps(planManagers, appliedMembers, stateManagers, stateMembers)
 
-	err = updateGroup(ctx, r.client.Client, state.ID.ValueString(), plan.Name.ValueString(), ops)
-	if err != nil {
-		resp.Diagnostics.AddError("Error updating group", err.Error())
+	if shouldUpdateGroup(plan.Name.ValueString(), currentName, ops) {
+		err = updateGroup(ctx, r.client.Client, state.ID.ValueString(), plan.Name.ValueString(), ops)
+		if err != nil {
+			resp.Diagnostics.AddError("Error updating group", err.Error())
 
-		return
+			return
+		}
 	}
 
 	plan.ID = state.ID
@@ -491,6 +493,10 @@ func buildGroupMembershipOps(
 	ops = appendRemovedGroupUsers(ops, userIDs, desired, current)
 
 	return ops
+}
+
+func shouldUpdateGroup(desiredName, currentName string, ops []helper.GroupMembershipOperation) bool {
+	return desiredName != currentName || len(ops) > 0
 }
 
 func appendMembershipRoleChanges(

--- a/internal/provider/group_resource.go
+++ b/internal/provider/group_resource.go
@@ -16,8 +16,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/passbolt/go-passbolt/api"
 )
 
 // Ensure interfaces
@@ -37,10 +39,11 @@ type groupResource struct {
 }
 
 type groupModel struct {
-	ID       types.String `tfsdk:"id"`
-	Name     types.String `tfsdk:"name"`
-	Managers types.Set    `tfsdk:"managers"`
-	Members  types.Set    `tfsdk:"members"`
+	ID                    types.String `tfsdk:"id"`
+	Name                  types.String `tfsdk:"name"`
+	Managers              types.Set    `tfsdk:"managers"`
+	Members               types.Set    `tfsdk:"members"`
+	IgnoreInactiveMembers types.Bool   `tfsdk:"ignore_inactive_members"`
 }
 
 func (r *groupResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
@@ -109,6 +112,15 @@ func (r *groupResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 					setvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1)),
 				},
 			},
+			"ignore_inactive_members": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  booldefault.StaticBool(false),
+				Description: "When true, inactive regular members that are not yet part of the group are " +
+					"skipped with a warning instead of failing the apply. Terraform will continue to plan " +
+					"those memberships until the users become active. Group managers remain strict and must " +
+					"already exist and be active in Passbolt.",
+			},
 		},
 	}
 }
@@ -121,18 +133,30 @@ func (r *groupResource) Create(ctx context.Context, req resource.CreateRequest, 
 	}
 
 	managers := setStringValues(ctx, plan.Managers, &resp.Diagnostics)
-	members := setStringValues(ctx, plan.Members, &resp.Diagnostics)
+	desiredMembers := setStringValues(ctx, plan.Members, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	if err := validateGroupMembershipConfig(managers, members); err != nil {
+	if err := validateGroupMembershipConfig(managers, desiredMembers); err != nil {
 		resp.Diagnostics.AddError("Invalid group membership", err.Error())
 
 		return
 	}
 
-	ops := buildCreateGroupMembershipOps(managers, members)
+	appliedMembers := resolveGroupMembersForApply(
+		ctx,
+		r.client.Client,
+		plan.IgnoreInactiveMembers.ValueBool(),
+		desiredMembers,
+		nil,
+		&resp.Diagnostics,
+	)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	ops := buildCreateGroupMembershipOps(managers, appliedMembers)
 
 	groupID, err := helper.CreateGroup(ctx, r.client.Client, plan.Name.ValueString(), ops)
 	if err != nil {
@@ -143,7 +167,8 @@ func (r *groupResource) Create(ctx context.Context, req resource.CreateRequest, 
 
 	plan.ID = types.StringValue(groupID)
 	plan.Managers = setStringValue(managers)
-	plan.Members = setStringValue(members)
+	plan.Members = setStringValue(desiredMembers)
+	plan.IgnoreInactiveMembers = types.BoolValue(plan.IgnoreInactiveMembers.ValueBool())
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -165,6 +190,9 @@ func (r *groupResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	managerIDs, memberIDs := splitGroupMemberships(memberships, true)
 	state.Managers = setStringValue(managerIDs)
 	state.Members = setStringValue(memberIDs)
+	if state.IgnoreInactiveMembers.IsNull() || state.IgnoreInactiveMembers.IsUnknown() {
+		state.IgnoreInactiveMembers = types.BoolValue(false)
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -182,12 +210,12 @@ func (r *groupResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 
 	planManagers := setStringValues(ctx, plan.Managers, &resp.Diagnostics)
-	planMembers := resolveGroupMembersForUpdate(ctx, configMembers, plan.Members, state.Members, &resp.Diagnostics)
+	desiredMembers := resolveGroupMembersForUpdate(ctx, configMembers, plan.Members, state.Members, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	if err := validateGroupMembershipConfig(planManagers, planMembers); err != nil {
+	if err := validateGroupMembershipConfig(planManagers, desiredMembers); err != nil {
 		resp.Diagnostics.AddError("Invalid group membership", err.Error())
 
 		return
@@ -201,7 +229,19 @@ func (r *groupResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 	stateManagers, stateMembers := splitGroupMemberships(memberships, true)
 
-	ops := buildGroupMembershipOps(planManagers, planMembers, stateManagers, stateMembers)
+	appliedMembers := resolveGroupMembersForApply(
+		ctx,
+		r.client.Client,
+		plan.IgnoreInactiveMembers.ValueBool(),
+		desiredMembers,
+		stateMembers,
+		&resp.Diagnostics,
+	)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	ops := buildGroupMembershipOps(planManagers, appliedMembers, stateManagers, stateMembers)
 
 	err = updateGroup(ctx, r.client.Client, state.ID.ValueString(), plan.Name.ValueString(), ops)
 	if err != nil {
@@ -212,8 +252,125 @@ func (r *groupResource) Update(ctx context.Context, req resource.UpdateRequest, 
 
 	plan.ID = state.ID
 	plan.Managers = setStringValue(planManagers)
-	plan.Members = setStringValue(planMembers)
+	plan.Members = setStringValue(desiredMembers)
+	plan.IgnoreInactiveMembers = types.BoolValue(plan.IgnoreInactiveMembers.ValueBool())
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func resolveGroupMembersForApply(
+	ctx context.Context,
+	client *api.Client,
+	ignoreInactiveMembers bool,
+	desiredMembers []types.String,
+	currentMembers []types.String,
+	diags *diag.Diagnostics,
+) []types.String {
+	if !ignoreInactiveMembers || !hasPendingGroupMembers(desiredMembers, currentMembers) {
+		return desiredMembers
+	}
+
+	filteredMembers, skippedMembers, err := filterInactivePendingGroupMembersForApply(
+		ctx,
+		client,
+		desiredMembers,
+		currentMembers,
+	)
+	if err != nil {
+		diags.AddError("Error resolving group members", err.Error())
+
+		return nil
+	}
+
+	addInactiveGroupMembersWarning(diags, skippedMembers)
+
+	return filteredMembers
+}
+
+func hasPendingGroupMembers(desiredMembers []types.String, currentMembers []types.String) bool {
+	if len(desiredMembers) == 0 {
+		return false
+	}
+
+	currentMemberSet := groupUserSet(currentMembers)
+	for _, member := range desiredMembers {
+		if !currentMemberSet[member.ValueString()] {
+			return true
+		}
+	}
+
+	return false
+}
+
+func filterInactivePendingGroupMembersForApply(
+	ctx context.Context,
+	client *api.Client,
+	desiredMembers []types.String,
+	currentMembers []types.String,
+) ([]types.String, []string, error) {
+	if len(desiredMembers) == 0 {
+		return desiredMembers, nil, nil
+	}
+
+	users, err := client.GetUsers(ctx, &api.GetUsersOptions{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("getting users: %w", err)
+	}
+
+	filteredMembers, skippedMembers := filterInactivePendingGroupMembers(desiredMembers, currentMembers, users)
+
+	return filteredMembers, skippedMembers, nil
+}
+
+func filterInactivePendingGroupMembers(
+	desiredMembers []types.String,
+	currentMembers []types.String,
+	users []api.User,
+) ([]types.String, []string) {
+	currentMemberSet := groupUserSet(currentMembers)
+	usersByID := make(map[string]api.User, len(users))
+	for _, user := range users {
+		usersByID[user.ID] = user
+	}
+
+	filteredMembers := make([]types.String, 0, len(desiredMembers))
+	skippedMembers := make([]string, 0)
+
+	for _, member := range desiredMembers {
+		userID := member.ValueString()
+		if currentMemberSet[userID] {
+			filteredMembers = append(filteredMembers, member)
+
+			continue
+		}
+
+		user, ok := usersByID[userID]
+		if !ok || user.Deleted || user.Active {
+			filteredMembers = append(filteredMembers, member)
+
+			continue
+		}
+
+		skippedMembers = append(skippedMembers, userID)
+	}
+
+	slices.Sort(skippedMembers)
+
+	return filteredMembers, skippedMembers
+}
+
+func addInactiveGroupMembersWarning(diags *diag.Diagnostics, skippedMembers []string) {
+	if len(skippedMembers) == 0 {
+		return
+	}
+
+	diags.AddWarning(
+		"Skipped inactive group members",
+		fmt.Sprintf(
+			"passbolt_group skipped inactive regular members %v because ignore_inactive_members is enabled. "+
+				"They will be retried on a later apply once the users activate their Passbolt accounts.",
+			skippedMembers,
+		),
+	)
 }
 
 func setStringValues(ctx context.Context, set types.Set, diags *diag.Diagnostics) []types.String {

--- a/internal/provider/group_resource_internal_test.go
+++ b/internal/provider/group_resource_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/passbolt/go-passbolt/api"
 	"github.com/passbolt/go-passbolt/helper"
 )
 
@@ -100,6 +101,15 @@ func TestGroupMembershipAttributesUseSetSemantics(t *testing.T) {
 	if len(setAttr.PlanModifiers) != 0 {
 		t.Fatalf("expected members to have no plan modifiers, got %d", len(setAttr.PlanModifiers))
 	}
+
+	ignoreInactiveAttr, ok := resp.Schema.Attributes["ignore_inactive_members"]
+	if !ok {
+		t.Fatal("expected ignore_inactive_members attribute in group schema")
+	}
+
+	if _, ok := ignoreInactiveAttr.(schema.BoolAttribute); !ok {
+		t.Fatalf("expected ignore_inactive_members to be a bool attribute, got %T", ignoreInactiveAttr)
+	}
 }
 
 func TestResolveGroupMembersForUpdate(t *testing.T) {
@@ -143,6 +153,127 @@ func TestResolveGroupMembersForUpdate(t *testing.T) {
 
 			assertResolvedGroupMembers(t, test.configMembers, test.planMembers, test.stateMembers, test.want)
 		})
+	}
+}
+
+func TestFilterInactivePendingGroupMembers(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		desiredMembers []types.String
+		currentMembers []types.String
+		users          []api.User
+		wantMembers    []types.String
+		wantSkipped    []string
+	}{
+		"skips inactive pending members": {
+			desiredMembers: stringValues("active-user", "inactive-user"),
+			users: []api.User{
+				{ID: "active-user", Active: true},
+				{ID: "inactive-user", Active: false},
+			},
+			wantMembers: stringValues("active-user"),
+			wantSkipped: []string{"inactive-user"},
+		},
+		"preserves existing inactive members": {
+			desiredMembers: stringValues("inactive-user"),
+			currentMembers: stringValues("inactive-user"),
+			users: []api.User{
+				{ID: "inactive-user", Active: false},
+			},
+			wantMembers: stringValues("inactive-user"),
+		},
+		"does not skip deleted or unknown users": {
+			desiredMembers: stringValues("deleted-user", "missing-user"),
+			users: []api.User{
+				{ID: "deleted-user", Active: false, Deleted: true},
+			},
+			wantMembers: stringValues("deleted-user", "missing-user"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			assertFilteredInactivePendingGroupMembers(
+				t,
+				test.desiredMembers,
+				test.currentMembers,
+				test.users,
+				test.wantMembers,
+				test.wantSkipped,
+			)
+		})
+	}
+}
+
+func TestHasPendingGroupMembers(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		desiredMembers []types.String
+		currentMembers []types.String
+		want           bool
+	}{
+		"returns false when desired list is empty": {
+			want: false,
+		},
+		"returns false when all desired members already exist": {
+			desiredMembers: stringValues("member-1"),
+			currentMembers: stringValues("member-1", "member-2"),
+			want:           false,
+		},
+		"returns true when at least one desired member is missing": {
+			desiredMembers: stringValues("member-1", "member-3"),
+			currentMembers: stringValues("member-1", "member-2"),
+			want:           true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := hasPendingGroupMembers(test.desiredMembers, test.currentMembers)
+			if got != test.want {
+				t.Fatalf("expected %t, got %t", test.want, got)
+			}
+		})
+	}
+}
+
+func assertFilteredInactivePendingGroupMembers(
+	t *testing.T,
+	desiredMembers []types.String,
+	currentMembers []types.String,
+	users []api.User,
+	wantMembers []types.String,
+	wantSkipped []string,
+) {
+	t.Helper()
+
+	gotMembers, gotSkipped := filterInactivePendingGroupMembers(
+		desiredMembers,
+		currentMembers,
+		users,
+	)
+
+	slices.SortFunc(gotMembers, compareStringValues)
+	slices.SortFunc(wantMembers, compareStringValues)
+
+	if len(gotMembers) != len(wantMembers) {
+		t.Fatalf("expected %d members, got %d: %#v", len(wantMembers), len(gotMembers), gotMembers)
+	}
+
+	for i := range wantMembers {
+		if gotMembers[i] != wantMembers[i] {
+			t.Fatalf("member %d: expected %#v, got %#v", i, wantMembers[i], gotMembers[i])
+		}
+	}
+
+	if strings.Join(gotSkipped, ",") != strings.Join(wantSkipped, ",") {
+		t.Fatalf("expected skipped %v, got %v", wantSkipped, gotSkipped)
 	}
 }
 

--- a/internal/provider/group_resource_internal_test.go
+++ b/internal/provider/group_resource_internal_test.go
@@ -183,6 +183,14 @@ func TestFilterInactivePendingGroupMembers(t *testing.T) {
 			},
 			wantMembers: stringValues("inactive-user"),
 		},
+		"preserves inactive current managers during demotion": {
+			desiredMembers: stringValues("inactive-manager"),
+			currentMembers: groupUserValues(stringValues("inactive-manager"), nil),
+			users: []api.User{
+				{ID: "inactive-manager", Active: false},
+			},
+			wantMembers: stringValues("inactive-manager"),
+		},
 		"does not skip deleted or unknown users": {
 			desiredMembers: stringValues("deleted-user", "missing-user"),
 			users: []api.User{

--- a/internal/provider/group_resource_internal_test.go
+++ b/internal/provider/group_resource_internal_test.go
@@ -391,6 +391,47 @@ func TestBuildGroupMembershipOps(t *testing.T) {
 	}
 }
 
+func TestShouldUpdateGroup(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		desiredName string
+		currentName string
+		ops         []helper.GroupMembershipOperation
+		want        bool
+	}{
+		"returns false for local-only flag changes": {
+			desiredName: "group-a",
+			currentName: "group-a",
+			want:        false,
+		},
+		"returns true when name changes": {
+			desiredName: "group-b",
+			currentName: "group-a",
+			want:        true,
+		},
+		"returns true when membership ops exist": {
+			desiredName: "group-a",
+			currentName: "group-a",
+			ops: []helper.GroupMembershipOperation{
+				{UserID: "member-1", IsGroupManager: false},
+			},
+			want: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := shouldUpdateGroup(test.desiredName, test.currentName, test.ops)
+			if got != test.want {
+				t.Fatalf("expected %t, got %t", test.want, got)
+			}
+		})
+	}
+}
+
 func stringValues(values ...string) []types.String {
 	result := make([]types.String, 0, len(values))
 	for _, value := range values {

--- a/internal/provider/group_resource_test.go
+++ b/internal/provider/group_resource_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -62,6 +63,59 @@ func TestAccPassboltGroup_withMembers(t *testing.T) {
 			testStepCreateGroupWithMembers(baseURL, privateKey, passphrase, managerID, memberID, groupName),
 			testStepNoDriftGroupWithMembers(baseURL, privateKey, passphrase, managerID, memberID, groupName),
 			testStepUpdateGroupWithMembers(baseURL, privateKey, passphrase, managerID, memberID, updatedGroupName),
+		},
+	})
+}
+
+func TestAccPassboltGroup_roleChanges(t *testing.T) {
+	t.Parallel()
+
+	requireAcceptanceEnv(
+		t,
+		"PASSBOLT_BASE_URL",
+		"PASSBOLT_PRIVATE_KEY",
+		"PASSBOLT_PASSPHRASE",
+		"PASSBOLT_MANAGER_ID",
+	)
+
+	baseURL := os.Getenv("PASSBOLT_BASE_URL")
+	privateKey := os.Getenv("PASSBOLT_PRIVATE_KEY")
+	passphrase := os.Getenv("PASSBOLT_PASSPHRASE")
+	managerID := os.Getenv("PASSBOLT_MANAGER_ID")
+	memberID := testAccGroupMemberID(t, baseURL, privateKey, passphrase, managerID)
+	suffix := testAccSuffix()
+	groupName := testAccName("test-group-role-change", suffix)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			testStepGroupRoleChange(
+				baseURL,
+				privateKey,
+				passphrase,
+				groupName,
+				[]string{managerID},
+				[]string{memberID},
+				map[string]bool{managerID: true, memberID: false},
+			),
+			testStepGroupRoleChange(
+				baseURL,
+				privateKey,
+				passphrase,
+				groupName,
+				[]string{managerID, memberID},
+				nil,
+				map[string]bool{managerID: true, memberID: true},
+			),
+			testStepGroupRoleChange(
+				baseURL,
+				privateKey,
+				passphrase,
+				groupName,
+				[]string{managerID},
+				[]string{memberID},
+				map[string]bool{managerID: true, memberID: false},
+			),
 		},
 	})
 }
@@ -436,6 +490,32 @@ func testStepUpdateGroupWithMembers(
 	}
 }
 
+func testStepGroupRoleChange(
+	baseURL,
+	privateKey,
+	passphrase,
+	groupName string,
+	managers,
+	members []string,
+	expectedRoles map[string]bool,
+) resource.TestStep {
+	return resource.TestStep{
+		Config: testGroupRoleChangeConfig(baseURL, privateKey, passphrase, groupName, managers, members),
+		Check: resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr("passbolt_group.test", "name", groupName),
+			resource.TestCheckResourceAttr("passbolt_group.test", "managers.#", fmt.Sprintf("%d", len(managers))),
+			resource.TestCheckResourceAttr("passbolt_group.test", "members.#", fmt.Sprintf("%d", len(members))),
+			testCheckGroupMembershipRoles(
+				baseURL,
+				privateKey,
+				passphrase,
+				"passbolt_group.test",
+				expectedRoles,
+			),
+		),
+	}
+}
+
 func testStepCreateSharedGroupPassword(
 	baseURL,
 	privateKey,
@@ -577,6 +657,40 @@ resource "passbolt_group" "test" {
 `, baseURL, privateKey, passphrase, groupName, managerID, memberID)
 }
 
+func testGroupRoleChangeConfig(
+	baseURL,
+	privateKey,
+	passphrase,
+	groupName string,
+	managers,
+	members []string,
+) string {
+	return fmt.Sprintf(`
+provider "passbolt" {
+  base_url    = "%s"
+  private_key = <<EOF
+%s
+EOF
+  passphrase  = "%s"
+}
+
+resource "passbolt_group" "test" {
+  name     = "%s"
+  managers = %s
+  members  = %s
+}
+`, baseURL, privateKey, passphrase, groupName, hclStringList(managers), hclStringList(members))
+}
+
+func hclStringList(values []string) string {
+	quoted := make([]string, 0, len(values))
+	for _, value := range values {
+		quoted = append(quoted, fmt.Sprintf("%q", value))
+	}
+
+	return fmt.Sprintf("[%s]", strings.Join(quoted, ", "))
+}
+
 func testGroupWithSharedPasswordConfig(
 	baseURL,
 	privateKey,
@@ -687,6 +801,65 @@ func testCheckSharedPasswordDecryptableAsMember(
 		}
 		if password != "shared-secret" {
 			return fmt.Errorf("expected shared resource password %q, got %q", "shared-secret", password)
+		}
+
+		return nil
+	}
+}
+
+func testCheckGroupMembershipRoles(
+	baseURL,
+	privateKey,
+	passphrase,
+	groupResourceName string,
+	expectedRoles map[string]bool,
+) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		groupResource, ok := state.RootModule().Resources[groupResourceName]
+		if !ok {
+			return fmt.Errorf("%s not found in Terraform state", groupResourceName)
+		}
+
+		groupID := groupResource.Primary.ID
+		if groupID == "" {
+			return fmt.Errorf("%s id is empty", groupResourceName)
+		}
+
+		ctx := context.Background()
+		client, err := api.NewClient(nil, "", baseURL, privateKey, passphrase)
+		if err != nil {
+			return fmt.Errorf("failed to create Passbolt API client: %w", err)
+		}
+		if err := client.Login(ctx); err != nil {
+			return fmt.Errorf("failed to log in to Passbolt API: %w", err)
+		}
+		defer func() {
+			_ = client.Logout(ctx)
+		}()
+
+		_, memberships, err := helper.GetGroup(ctx, client, groupID)
+		if err != nil {
+			return fmt.Errorf("failed to get Passbolt group %s: %w", groupID, err)
+		}
+
+		actualRoles := make(map[string]bool, len(memberships))
+		for _, membership := range memberships {
+			actualRoles[membership.UserID] = membership.IsGroupManager
+		}
+
+		for userID, expectedManager := range expectedRoles {
+			actualManager, ok := actualRoles[userID]
+			if !ok {
+				return fmt.Errorf("expected user %s in group %s", userID, groupID)
+			}
+			if actualManager != expectedManager {
+				return fmt.Errorf(
+					"expected user %s manager role to be %t, got %t",
+					userID,
+					expectedManager,
+					actualManager,
+				)
+			}
 		}
 
 		return nil

--- a/internal/provider/group_resource_test.go
+++ b/internal/provider/group_resource_test.go
@@ -135,6 +135,67 @@ func TestAccPassboltGroup_addMemberToSharedGroupCanDecryptSecret(t *testing.T) {
 	})
 }
 
+func TestAccPassboltGroup_ignoreInactiveMembers(t *testing.T) {
+	t.Parallel()
+
+	requireAcceptanceEnv(
+		t,
+		"PASSBOLT_BASE_URL",
+		"PASSBOLT_PRIVATE_KEY",
+		"PASSBOLT_PASSPHRASE",
+	)
+
+	baseURL := os.Getenv("PASSBOLT_BASE_URL")
+	privateKey := os.Getenv("PASSBOLT_PRIVATE_KEY")
+	passphrase := os.Getenv("PASSBOLT_PASSPHRASE")
+	managerID := testAccCurrentUserID(t, baseURL, privateKey, passphrase)
+	suffix := testAccSuffix()
+	groupName := testAccName("test-group-ignore-inactive", suffix)
+	email := testAccEmail("inactive.member", suffix)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testGroupIgnoreInactiveMembersConfig(
+					baseURL,
+					privateKey,
+					passphrase,
+					managerID,
+					email,
+					groupName,
+				),
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("passbolt_group.test", "name", groupName),
+					resource.TestCheckResourceAttr("passbolt_group.test", "managers.#", "1"),
+					resource.TestCheckResourceAttr("passbolt_group.test", "ignore_inactive_members", "true"),
+					resource.TestCheckResourceAttr("passbolt_user.member", "username", email),
+					testCheckGroupDoesNotContainMember(
+						baseURL,
+						privateKey,
+						passphrase,
+						"passbolt_group.test",
+						"passbolt_user.member",
+					),
+				),
+			},
+			{
+				Config: testGroupIgnoreInactiveMembersConfig(
+					baseURL,
+					privateKey,
+					passphrase,
+					managerID,
+					email,
+					groupName,
+				),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccGroupMemberID(t *testing.T, baseURL, privateKey, passphrase, managerID string) string {
 	t.Helper()
 
@@ -555,6 +616,32 @@ resource "passbolt_password" "shared" {
 `, baseURL, privateKey, passphrase, groupName, managerID, members, passwordName)
 }
 
+func testGroupIgnoreInactiveMembersConfig(baseURL, privateKey, passphrase, managerID, email, groupName string) string {
+	return fmt.Sprintf(`
+provider "passbolt" {
+  base_url    = "%s"
+  private_key = <<EOF
+%s
+EOF
+  passphrase  = "%s"
+}
+
+resource "passbolt_user" "member" {
+  username   = "%s"
+  first_name = "Pending"
+  last_name  = "Member"
+  role       = "user"
+}
+
+resource "passbolt_group" "test" {
+  name                    = "%s"
+  managers                = ["%s"]
+  members                 = [passbolt_user.member.id]
+  ignore_inactive_members = true
+}
+`, baseURL, privateKey, passphrase, email, groupName, managerID)
+}
+
 func testCheckSharedPasswordDecryptableAsMember(
 	baseURL,
 	memberPrivateKey,
@@ -600,6 +687,57 @@ func testCheckSharedPasswordDecryptableAsMember(
 		}
 		if password != "shared-secret" {
 			return fmt.Errorf("expected shared resource password %q, got %q", "shared-secret", password)
+		}
+
+		return nil
+	}
+}
+
+func testCheckGroupDoesNotContainMember(
+	baseURL,
+	privateKey,
+	passphrase,
+	groupResourceName,
+	userResourceName string,
+) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		groupResource, ok := state.RootModule().Resources[groupResourceName]
+		if !ok {
+			return fmt.Errorf("%s not found in Terraform state", groupResourceName)
+		}
+
+		userResource, ok := state.RootModule().Resources[userResourceName]
+		if !ok {
+			return fmt.Errorf("%s not found in Terraform state", userResourceName)
+		}
+
+		groupID := groupResource.Primary.ID
+		userID := userResource.Primary.ID
+		if groupID == "" || userID == "" {
+			return fmt.Errorf("group id %q or user id %q is empty", groupID, userID)
+		}
+
+		ctx := context.Background()
+		client, err := api.NewClient(nil, "", baseURL, privateKey, passphrase)
+		if err != nil {
+			return fmt.Errorf("failed to create Passbolt API client: %w", err)
+		}
+		if err := client.Login(ctx); err != nil {
+			return fmt.Errorf("failed to log in to Passbolt API: %w", err)
+		}
+		defer func() {
+			_ = client.Logout(ctx)
+		}()
+
+		_, memberships, err := helper.GetGroup(ctx, client, groupID)
+		if err != nil {
+			return fmt.Errorf("failed to get Passbolt group %s: %w", groupID, err)
+		}
+
+		for _, membership := range memberships {
+			if membership.UserID == userID {
+				return fmt.Errorf("expected inactive user %s to be skipped from group %s", userID, groupID)
+			}
 		}
 
 		return nil

--- a/templates/guides/onboarding.md.tmpl
+++ b/templates/guides/onboarding.md.tmpl
@@ -18,6 +18,8 @@ Passbolt user onboarding is usually a two-step workflow:
 
 ~> A newly created user may not be available for `passbolt_group` membership in the same apply. Wait until the invitation is accepted and the user is active.
 
+If you already know the invited user's UUID and want Terraform to keep retrying regular group membership after activation, you can enable `ignore_inactive_members = true` on `passbolt_group`. This skips inactive regular members that are already visible to the Passbolt API with a warning and retries them on later applies. Terraform will continue to show the pending membership change until the user becomes active. Unknown or deleted user IDs still fail normally. Group managers still must already be active.
+
 ## Step 2: Add the Active User to a Group and Shared Folder
 
 {{ tffile "examples/guides/onboarding/assign-group.tf" }}


### PR DESCRIPTION
## Changes

- added `passbolt_group.ignore_inactive_members` to support deferred regular-member onboarding
- skipped inactive regular members with a warning instead of failing the apply when the flag is enabled
- kept group managers strict so at least one active manager is still required
- retried skipped regular members on later applies once they become active
- avoided unnecessary `GetUsers` calls on updates that do not have pending member additions
- added unit coverage for inactive-member filtering and pending-member detection
- added acceptance coverage for the inactive-member workflow
- updated the README, onboarding guide, generated docs, and changelog for `v1.7.0`

## Motivation

In larger organizations, invited users do not always activate their Passbolt accounts immediately. Today that blocks `passbolt_group` management when such users are present in the desired member list.

This change adds an opt-in workflow for regular members so Terraform can continue applying group changes while deferring inactive memberships until those users activate their accounts.

## Testing

- `make docs`
- `make lint`
- `go test ./internal/provider -count=1`
- `TF_ACC=1 go test ./internal/provider -run TestAccPassboltGroup_ignoreInactiveMembers -count=1 -v`

## Risks & Rollback

- This is a backward-compatible additive change because the new behavior is gated behind `ignore_inactive_members = true`
- Managers remain strict, so privileged access semantics are unchanged
- When the flag is enabled, Terraform will continue to show pending membership diffs until skipped users become active
- Rollback is straightforward: revert this PR and release a follow-up version
